### PR TITLE
mapped: implement findall_long

### DIFF
--- a/src/array-aho.h
+++ b/src/array-aho.h
@@ -224,6 +224,10 @@ public:
                           int* inout_start,
                           int* out_end) const;
 
+   PayloadT find_longest(char const* s, size_t n,
+                       int* inout_start,
+                       int* out_end) const ;
+
    int num_nodes() const;
 
    virtual Node::Index child_at(Node::Index i, AC_CHAR_TYPE c) const;

--- a/src/noahong.cpp
+++ b/src/noahong.cpp
@@ -835,7 +835,7 @@ struct __pyx_obj_7noahong_AhoIterator;
 struct __pyx_obj_7noahong_MappedIterator;
 struct __pyx_obj_7noahong_Mapped;
 
-/* "noahong.pyx":80
+/* "noahong.pyx":82
  *     pass
  * 
  * cdef class NoAho:             # <<<<<<<<<<<<<<
@@ -850,7 +850,7 @@ struct __pyx_obj_7noahong_NoAho {
 };
 
 
-/* "noahong.pyx":237
+/* "noahong.pyx":239
  * 
  * # http://groups.google.com/group/cython-users/browse_thread/thread/69b6eeb930826bcb/0b20e6e265e719a3?lnk=gst&q=iterator#0b20e6e265e719a3
  * cdef class AhoIterator:             # <<<<<<<<<<<<<<
@@ -869,7 +869,7 @@ struct __pyx_obj_7noahong_AhoIterator {
 };
 
 
-/* "noahong.pyx":294
+/* "noahong.pyx":296
  * 
  * 
  * cdef class MappedIterator:             # <<<<<<<<<<<<<<
@@ -884,10 +884,11 @@ struct __pyx_obj_7noahong_MappedIterator {
   int num_utf8_chars;
   int start;
   int end;
+  int want_longest;
 };
 
 
-/* "noahong.pyx":332
+/* "noahong.pyx":340
  * 
  * 
  * cdef class Mapped:             # <<<<<<<<<<<<<<
@@ -1467,7 +1468,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_2__iter__(struct __pyx_obj_7noa
 static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noahong_AhoIterator *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_7noahong_11AhoIterator_6__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_AhoIterator *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_7noahong_11AhoIterator_8__setstate_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_AhoIterator *__pyx_v_self, CYTHON_UNUSED PyObject *__pyx_v___pyx_state); /* proto */
-static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self, PyObject *__pyx_v_mapped, PyObject *__pyx_v_utf8_data, PyObject *__pyx_v_num_utf8_chars); /* proto */
+static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self, PyObject *__pyx_v_mapped, PyObject *__pyx_v_utf8_data, PyObject *__pyx_v_num_utf8_chars, PyObject *__pyx_v_want_longest); /* proto */
 static PyObject *__pyx_pf_7noahong_14MappedIterator_2__iter__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_7noahong_14MappedIterator_6__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self); /* proto */
@@ -1475,10 +1476,11 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_8__setstate_cython__(CYTHON_
 static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_path); /* proto */
 static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
 static PyObject *__pyx_pf_7noahong_6Mapped_4close(struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text); /* proto */
-static PyObject *__pyx_pf_7noahong_6Mapped_8nodes_count(struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_7noahong_6Mapped_10__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_7noahong_6Mapped_12__setstate_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self, CYTHON_UNUSED PyObject *__pyx_v___pyx_state); /* proto */
+static PyObject *__pyx_pf_7noahong_6Mapped_6findall_long(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text); /* proto */
+static PyObject *__pyx_pf_7noahong_6Mapped_8findall_anchored(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text); /* proto */
+static PyObject *__pyx_pf_7noahong_6Mapped_10nodes_count(struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_7noahong_6Mapped_12__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_7noahong_6Mapped_14__setstate_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self, CYTHON_UNUSED PyObject *__pyx_v___pyx_state); /* proto */
 static PyObject *__pyx_tp_new_7noahong_NoAho(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_7noahong_AhoIterator(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_7noahong_MappedIterator(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
@@ -1643,7 +1645,7 @@ static PyObject *__pyx_f_7noahong_get_as_utf8(PyObject *__pyx_v_text) {
   return __pyx_r;
 }
 
-/* "noahong.pyx":85
+/* "noahong.pyx":87
  *     cdef int has_noninteger_payload
  * 
  *     def __cinit__(self):             # <<<<<<<<<<<<<<
@@ -1676,7 +1678,7 @@ static int __pyx_pf_7noahong_5NoAho___cinit__(struct __pyx_obj_7noahong_NoAho *_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "noahong.pyx":86
+  /* "noahong.pyx":88
  * 
  *     def __cinit__(self):
  *         self.thisptr = new AhoCorasickTrie()             # <<<<<<<<<<<<<<
@@ -1685,14 +1687,14 @@ static int __pyx_pf_7noahong_5NoAho___cinit__(struct __pyx_obj_7noahong_NoAho *_
  */
   __pyx_v_self->thisptr = new AhoCorasickTrie();
 
-  /* "noahong.pyx":87
+  /* "noahong.pyx":89
  *     def __cinit__(self):
  *         self.thisptr = new AhoCorasickTrie()
  *         self.payloads_to_decref = []             # <<<<<<<<<<<<<<
  *         self.has_noninteger_payload = 0
  * 
  */
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 87, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 89, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
   __Pyx_GOTREF(__pyx_v_self->payloads_to_decref);
@@ -1700,7 +1702,7 @@ static int __pyx_pf_7noahong_5NoAho___cinit__(struct __pyx_obj_7noahong_NoAho *_
   __pyx_v_self->payloads_to_decref = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":88
+  /* "noahong.pyx":90
  *         self.thisptr = new AhoCorasickTrie()
  *         self.payloads_to_decref = []
  *         self.has_noninteger_payload = 0             # <<<<<<<<<<<<<<
@@ -1709,7 +1711,7 @@ static int __pyx_pf_7noahong_5NoAho___cinit__(struct __pyx_obj_7noahong_NoAho *_
  */
   __pyx_v_self->has_noninteger_payload = 0;
 
-  /* "noahong.pyx":85
+  /* "noahong.pyx":87
  *     cdef int has_noninteger_payload
  * 
  *     def __cinit__(self):             # <<<<<<<<<<<<<<
@@ -1729,7 +1731,7 @@ static int __pyx_pf_7noahong_5NoAho___cinit__(struct __pyx_obj_7noahong_NoAho *_
   return __pyx_r;
 }
 
-/* "noahong.pyx":90
+/* "noahong.pyx":92
  *         self.has_noninteger_payload = 0
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -1760,7 +1762,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__dealloc__", 0);
 
-  /* "noahong.pyx":91
+  /* "noahong.pyx":93
  * 
  *     def __dealloc__(self):
  *         for payload in self.payloads_to_decref:             # <<<<<<<<<<<<<<
@@ -1771,26 +1773,26 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
     __pyx_t_1 = __pyx_v_self->payloads_to_decref; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
     __pyx_t_3 = NULL;
   } else {
-    __pyx_t_2 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_self->payloads_to_decref); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 91, __pyx_L1_error)
+    __pyx_t_2 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_self->payloads_to_decref); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 93, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 91, __pyx_L1_error)
+    __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 93, __pyx_L1_error)
   }
   for (;;) {
     if (likely(!__pyx_t_3)) {
       if (likely(PyList_CheckExact(__pyx_t_1))) {
         if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 91, __pyx_L1_error)
+        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 93, __pyx_L1_error)
         #else
-        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 91, __pyx_L1_error)
+        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 93, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         #endif
       } else {
         if (__pyx_t_2 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-        __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 91, __pyx_L1_error)
+        __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(0, 93, __pyx_L1_error)
         #else
-        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 91, __pyx_L1_error)
+        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 93, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         #endif
       }
@@ -1800,7 +1802,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
         PyObject* exc_type = PyErr_Occurred();
         if (exc_type) {
           if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-          else __PYX_ERR(0, 91, __pyx_L1_error)
+          else __PYX_ERR(0, 93, __pyx_L1_error)
         }
         break;
       }
@@ -1809,7 +1811,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
     __Pyx_XDECREF_SET(__pyx_v_payload, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "noahong.pyx":92
+    /* "noahong.pyx":94
  *     def __dealloc__(self):
  *         for payload in self.payloads_to_decref:
  *             Py_DECREF(payload)             # <<<<<<<<<<<<<<
@@ -1818,7 +1820,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
  */
     Py_DECREF(__pyx_v_payload);
 
-    /* "noahong.pyx":91
+    /* "noahong.pyx":93
  * 
  *     def __dealloc__(self):
  *         for payload in self.payloads_to_decref:             # <<<<<<<<<<<<<<
@@ -1828,7 +1830,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "noahong.pyx":93
+  /* "noahong.pyx":95
  *         for payload in self.payloads_to_decref:
  *             Py_DECREF(payload)
  *         del self.thisptr             # <<<<<<<<<<<<<<
@@ -1837,7 +1839,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
  */
   delete __pyx_v_self->thisptr;
 
-  /* "noahong.pyx":90
+  /* "noahong.pyx":92
  *         self.has_noninteger_payload = 0
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -1856,7 +1858,7 @@ static void __pyx_pf_7noahong_5NoAho_2__dealloc__(struct __pyx_obj_7noahong_NoAh
   __Pyx_RefNannyFinishContext();
 }
 
-/* "noahong.pyx":95
+/* "noahong.pyx":97
  *         del self.thisptr
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -1882,7 +1884,7 @@ static Py_ssize_t __pyx_pf_7noahong_5NoAho_4__len__(struct __pyx_obj_7noahong_No
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__len__", 0);
 
-  /* "noahong.pyx":96
+  /* "noahong.pyx":98
  * 
  *     def __len__(self):
  *         return self.thisptr.num_keys()             # <<<<<<<<<<<<<<
@@ -1892,7 +1894,7 @@ static Py_ssize_t __pyx_pf_7noahong_5NoAho_4__len__(struct __pyx_obj_7noahong_No
   __pyx_r = __pyx_v_self->thisptr->num_keys();
   goto __pyx_L0;
 
-  /* "noahong.pyx":95
+  /* "noahong.pyx":97
  *         del self.thisptr
  * 
  *     def __len__(self):             # <<<<<<<<<<<<<<
@@ -1906,7 +1908,7 @@ static Py_ssize_t __pyx_pf_7noahong_5NoAho_4__len__(struct __pyx_obj_7noahong_No
   return __pyx_r;
 }
 
-/* "noahong.pyx":98
+/* "noahong.pyx":100
  *         return self.thisptr.num_keys()
  * 
  *     def nodes_count(self):             # <<<<<<<<<<<<<<
@@ -1936,7 +1938,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_6nodes_count(struct __pyx_obj_7noahong
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("nodes_count", 0);
 
-  /* "noahong.pyx":99
+  /* "noahong.pyx":101
  * 
  *     def nodes_count(self):
  *         return self.thisptr.num_nodes()             # <<<<<<<<<<<<<<
@@ -1944,13 +1946,13 @@ static PyObject *__pyx_pf_7noahong_5NoAho_6nodes_count(struct __pyx_obj_7noahong
  *     def children_count(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->thisptr->num_nodes()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 99, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->thisptr->num_nodes()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 101, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":98
+  /* "noahong.pyx":100
  *         return self.thisptr.num_keys()
  * 
  *     def nodes_count(self):             # <<<<<<<<<<<<<<
@@ -1969,7 +1971,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_6nodes_count(struct __pyx_obj_7noahong
   return __pyx_r;
 }
 
-/* "noahong.pyx":101
+/* "noahong.pyx":103
  *         return self.thisptr.num_nodes()
  * 
  *     def children_count(self):             # <<<<<<<<<<<<<<
@@ -1999,7 +2001,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_8children_count(struct __pyx_obj_7noah
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("children_count", 0);
 
-  /* "noahong.pyx":102
+  /* "noahong.pyx":104
  * 
  *     def children_count(self):
  *         return self.thisptr.num_total_children()             # <<<<<<<<<<<<<<
@@ -2007,13 +2009,13 @@ static PyObject *__pyx_pf_7noahong_5NoAho_8children_count(struct __pyx_obj_7noah
  *     def write(self, path):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->thisptr->num_total_children()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 102, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->thisptr->num_total_children()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 104, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":101
+  /* "noahong.pyx":103
  *         return self.thisptr.num_nodes()
  * 
  *     def children_count(self):             # <<<<<<<<<<<<<<
@@ -2032,7 +2034,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_8children_count(struct __pyx_obj_7noah
   return __pyx_r;
 }
 
-/* "noahong.pyx":104
+/* "noahong.pyx":106
  *         return self.thisptr.num_total_children()
  * 
  *     def write(self, path):             # <<<<<<<<<<<<<<
@@ -2071,14 +2073,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("write", 0);
 
-  /* "noahong.pyx":107
+  /* "noahong.pyx":109
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(path)             # <<<<<<<<<<<<<<
  *         if self.has_noninteger_payload:
  *             raise PayloadWriteError("Cannot write a NoAho trie with non integer payload.")
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_path); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 107, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_path); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 109, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -2086,7 +2088,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 107, __pyx_L1_error)
+      __PYX_ERR(0, 109, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -2099,15 +2101,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 107, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 109, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 107, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 109, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 107, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 109, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -2115,7 +2117,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 107, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 109, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -2123,17 +2125,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 107, __pyx_L1_error)
+    __PYX_ERR(0, 109, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 107, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 107, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 109, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 109, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":108
+  /* "noahong.pyx":110
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(path)
  *         if self.has_noninteger_payload:             # <<<<<<<<<<<<<<
@@ -2143,14 +2145,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
   __pyx_t_7 = (__pyx_v_self->has_noninteger_payload != 0);
   if (unlikely(__pyx_t_7)) {
 
-    /* "noahong.pyx":109
+    /* "noahong.pyx":111
  *         utf8_data, num_utf8_chars = get_as_utf8(path)
  *         if self.has_noninteger_payload:
  *             raise PayloadWriteError("Cannot write a NoAho trie with non integer payload.")             # <<<<<<<<<<<<<<
  *         self.thisptr.write(utf8_data, num_utf8_chars)
  * 
  */
-    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_PayloadWriteError); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 109, __pyx_L1_error)
+    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_PayloadWriteError); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 111, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_t_2 = NULL;
     if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -2164,14 +2166,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_kp_s_Cannot_write_a_NoAho_trie_with_n) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_kp_s_Cannot_write_a_NoAho_trie_with_n);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 109, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 111, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 109, __pyx_L1_error)
+    __PYX_ERR(0, 111, __pyx_L1_error)
 
-    /* "noahong.pyx":108
+    /* "noahong.pyx":110
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(path)
  *         if self.has_noninteger_payload:             # <<<<<<<<<<<<<<
@@ -2180,7 +2182,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
  */
   }
 
-  /* "noahong.pyx":110
+  /* "noahong.pyx":112
  *         if self.has_noninteger_payload:
  *             raise PayloadWriteError("Cannot write a NoAho trie with non integer payload.")
  *         self.thisptr.write(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
@@ -2189,17 +2191,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 110, __pyx_L1_error)
+    __PYX_ERR(0, 112, __pyx_L1_error)
   }
-  __pyx_t_8 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_8) && PyErr_Occurred())) __PYX_ERR(0, 110, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_8) && PyErr_Occurred())) __PYX_ERR(0, 112, __pyx_L1_error)
   try {
     __pyx_v_self->thisptr->write(__pyx_t_8, __pyx_v_num_utf8_chars);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 110, __pyx_L1_error)
+    __PYX_ERR(0, 112, __pyx_L1_error)
   }
 
-  /* "noahong.pyx":104
+  /* "noahong.pyx":106
  *         return self.thisptr.num_total_children()
  * 
  *     def write(self, path):             # <<<<<<<<<<<<<<
@@ -2224,7 +2226,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_10write(struct __pyx_obj_7noahong_NoAh
   return __pyx_r;
 }
 
-/* "noahong.pyx":112
+/* "noahong.pyx":114
  *         self.thisptr.write(utf8_data, num_utf8_chars)
  * 
  *     def __contains__(self, key_text):             # <<<<<<<<<<<<<<
@@ -2262,14 +2264,14 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__contains__", 0);
 
-  /* "noahong.pyx":115
+  /* "noahong.pyx":117
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(key_text)             # <<<<<<<<<<<<<<
  *         return self.thisptr.contains(utf8_data, num_utf8_chars)
  * 
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_key_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 115, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_key_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -2277,7 +2279,7 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 115, __pyx_L1_error)
+      __PYX_ERR(0, 117, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -2290,15 +2292,15 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 115, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 117, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 115, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 117, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 115, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 117, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -2306,7 +2308,7 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 115, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 117, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -2314,17 +2316,17 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 115, __pyx_L1_error)
+    __PYX_ERR(0, 117, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 115, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 115, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 117, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 117, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":116
+  /* "noahong.pyx":118
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(key_text)
  *         return self.thisptr.contains(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
@@ -2333,19 +2335,19 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 116, __pyx_L1_error)
+    __PYX_ERR(0, 118, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 116, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 118, __pyx_L1_error)
   try {
     __pyx_t_6 = __pyx_v_self->thisptr->contains(__pyx_t_7, __pyx_v_num_utf8_chars);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 116, __pyx_L1_error)
+    __PYX_ERR(0, 118, __pyx_L1_error)
   }
   __pyx_r = __pyx_t_6;
   goto __pyx_L0;
 
-  /* "noahong.pyx":112
+  /* "noahong.pyx":114
  *         self.thisptr.write(utf8_data, num_utf8_chars)
  * 
  *     def __contains__(self, key_text):             # <<<<<<<<<<<<<<
@@ -2367,7 +2369,7 @@ static int __pyx_pf_7noahong_5NoAho_12__contains__(struct __pyx_obj_7noahong_NoA
   return __pyx_r;
 }
 
-/* "noahong.pyx":118
+/* "noahong.pyx":120
  *         return self.thisptr.contains(utf8_data, num_utf8_chars)
  * 
  *     def __getitem__(self, text):             # <<<<<<<<<<<<<<
@@ -2407,14 +2409,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__getitem__", 0);
 
-  /* "noahong.pyx":122
+  /* "noahong.pyx":124
  *         cdef int num_utf8_chars
  *         cdef int32_t payload_index
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         payload_index = self.thisptr.get_payload(utf8_data, num_utf8_chars)
  *         if payload_index < 0:
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 124, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -2422,7 +2424,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 122, __pyx_L1_error)
+      __PYX_ERR(0, 124, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -2435,15 +2437,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 124, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 122, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 124, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 122, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 124, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -2451,7 +2453,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 122, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 124, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -2459,17 +2461,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 122, __pyx_L1_error)
+    __PYX_ERR(0, 124, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 122, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 122, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 124, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 124, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":123
+  /* "noahong.pyx":125
  *         cdef int32_t payload_index
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         payload_index = self.thisptr.get_payload(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
@@ -2478,18 +2480,18 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 123, __pyx_L1_error)
+    __PYX_ERR(0, 125, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 123, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 125, __pyx_L1_error)
   try {
     __pyx_t_6 = __pyx_v_self->thisptr->get_payload(__pyx_t_7, __pyx_v_num_utf8_chars);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 123, __pyx_L1_error)
+    __PYX_ERR(0, 125, __pyx_L1_error)
   }
   __pyx_v_payload_index = __pyx_t_6;
 
-  /* "noahong.pyx":124
+  /* "noahong.pyx":126
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         payload_index = self.thisptr.get_payload(utf8_data, num_utf8_chars)
  *         if payload_index < 0:             # <<<<<<<<<<<<<<
@@ -2499,20 +2501,20 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
   __pyx_t_8 = ((__pyx_v_payload_index < 0) != 0);
   if (unlikely(__pyx_t_8)) {
 
-    /* "noahong.pyx":125
+    /* "noahong.pyx":127
  *         payload_index = self.thisptr.get_payload(utf8_data, num_utf8_chars)
  *         if payload_index < 0:
  *             raise KeyError(text)             # <<<<<<<<<<<<<<
  *         return self.payloads_to_decref[payload_index]
  * 
  */
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_builtin_KeyError, __pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 125, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_builtin_KeyError, __pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 127, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 125, __pyx_L1_error)
+    __PYX_ERR(0, 127, __pyx_L1_error)
 
-    /* "noahong.pyx":124
+    /* "noahong.pyx":126
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         payload_index = self.thisptr.get_payload(utf8_data, num_utf8_chars)
  *         if payload_index < 0:             # <<<<<<<<<<<<<<
@@ -2521,7 +2523,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
  */
   }
 
-  /* "noahong.pyx":126
+  /* "noahong.pyx":128
  *         if payload_index < 0:
  *             raise KeyError(text)
  *         return self.payloads_to_decref[payload_index]             # <<<<<<<<<<<<<<
@@ -2529,13 +2531,13 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
  *     def __setitem__(self, text, py_payload):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 128, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":118
+  /* "noahong.pyx":120
  *         return self.thisptr.contains(utf8_data, num_utf8_chars)
  * 
  *     def __getitem__(self, text):             # <<<<<<<<<<<<<<
@@ -2558,7 +2560,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_14__getitem__(struct __pyx_obj_7noahon
   return __pyx_r;
 }
 
-/* "noahong.pyx":128
+/* "noahong.pyx":130
  *         return self.payloads_to_decref[payload_index]
  * 
  *     def __setitem__(self, text, py_payload):             # <<<<<<<<<<<<<<
@@ -2592,14 +2594,14 @@ static int __pyx_pf_7noahong_5NoAho_16__setitem__(struct __pyx_obj_7noahong_NoAh
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__setitem__", 0);
 
-  /* "noahong.pyx":129
+  /* "noahong.pyx":131
  * 
  *     def __setitem__(self, text, py_payload):
  *         self.add(text, py_payload)             # <<<<<<<<<<<<<<
  * 
  * # This is harder...
  */
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_add); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 129, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_add); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   __pyx_t_4 = 0;
@@ -2616,7 +2618,7 @@ static int __pyx_pf_7noahong_5NoAho_16__setitem__(struct __pyx_obj_7noahong_NoAh
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[3] = {__pyx_t_3, __pyx_v_text, __pyx_v_py_payload};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_4, 2+__pyx_t_4); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 129, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_4, 2+__pyx_t_4); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else
@@ -2624,13 +2626,13 @@ static int __pyx_pf_7noahong_5NoAho_16__setitem__(struct __pyx_obj_7noahong_NoAh
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[3] = {__pyx_t_3, __pyx_v_text, __pyx_v_py_payload};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_4, 2+__pyx_t_4); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 129, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_4, 2+__pyx_t_4); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else
   #endif
   {
-    __pyx_t_5 = PyTuple_New(2+__pyx_t_4); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 129, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_New(2+__pyx_t_4); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     if (__pyx_t_3) {
       __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_3); __pyx_t_3 = NULL;
@@ -2641,14 +2643,14 @@ static int __pyx_pf_7noahong_5NoAho_16__setitem__(struct __pyx_obj_7noahong_NoAh
     __Pyx_INCREF(__pyx_v_py_payload);
     __Pyx_GIVEREF(__pyx_v_py_payload);
     PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_4, __pyx_v_py_payload);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 129, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "noahong.pyx":128
+  /* "noahong.pyx":130
  *         return self.payloads_to_decref[payload_index]
  * 
  *     def __setitem__(self, text, py_payload):             # <<<<<<<<<<<<<<
@@ -2671,7 +2673,7 @@ static int __pyx_pf_7noahong_5NoAho_16__setitem__(struct __pyx_obj_7noahong_NoAh
   return __pyx_r;
 }
 
-/* "noahong.pyx":135
+/* "noahong.pyx":137
  * #        return
  * 
  *     def add(self, text, py_payload = None):             # <<<<<<<<<<<<<<
@@ -2718,7 +2720,7 @@ static PyObject *__pyx_pw_7noahong_5NoAho_19add(PyObject *__pyx_v_self, PyObject
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add") < 0)) __PYX_ERR(0, 135, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "add") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -2734,7 +2736,7 @@ static PyObject *__pyx_pw_7noahong_5NoAho_19add(PyObject *__pyx_v_self, PyObject
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("add", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 135, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("add", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("noahong.NoAho.add", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -2769,14 +2771,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("add", 0);
 
-  /* "noahong.pyx":140
+  /* "noahong.pyx":142
  *         cdef int32_t payload_index
  * 
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  * 
  *         if num_utf8_chars == 0:
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 140, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 142, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -2784,7 +2786,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 140, __pyx_L1_error)
+      __PYX_ERR(0, 142, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -2797,15 +2799,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 142, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 142, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 140, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 142, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -2813,7 +2815,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 140, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 142, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -2821,17 +2823,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 140, __pyx_L1_error)
+    __PYX_ERR(0, 142, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 140, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 140, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 142, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 142, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":142
+  /* "noahong.pyx":144
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  * 
  *         if num_utf8_chars == 0:             # <<<<<<<<<<<<<<
@@ -2841,20 +2843,20 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
   __pyx_t_7 = ((__pyx_v_num_utf8_chars == 0) != 0);
   if (unlikely(__pyx_t_7)) {
 
-    /* "noahong.pyx":143
+    /* "noahong.pyx":145
  * 
  *         if num_utf8_chars == 0:
  *             raise ValueError("Key cannot be empty (would cause Aho-Corasick automaton to spin)")             # <<<<<<<<<<<<<<
  * 
  *         payload_index = -1
  */
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 145, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 143, __pyx_L1_error)
+    __PYX_ERR(0, 145, __pyx_L1_error)
 
-    /* "noahong.pyx":142
+    /* "noahong.pyx":144
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  * 
  *         if num_utf8_chars == 0:             # <<<<<<<<<<<<<<
@@ -2863,7 +2865,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
   }
 
-  /* "noahong.pyx":145
+  /* "noahong.pyx":147
  *             raise ValueError("Key cannot be empty (would cause Aho-Corasick automaton to spin)")
  * 
  *         payload_index = -1             # <<<<<<<<<<<<<<
@@ -2872,7 +2874,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
   __pyx_v_payload_index = -1;
 
-  /* "noahong.pyx":146
+  /* "noahong.pyx":148
  * 
  *         payload_index = -1
  *         if not isinstance(py_payload, int):             # <<<<<<<<<<<<<<
@@ -2883,7 +2885,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
   __pyx_t_8 = ((!(__pyx_t_7 != 0)) != 0);
   if (__pyx_t_8) {
 
-    /* "noahong.pyx":147
+    /* "noahong.pyx":149
  *         payload_index = -1
  *         if not isinstance(py_payload, int):
  *             self.has_noninteger_payload = 1             # <<<<<<<<<<<<<<
@@ -2892,7 +2894,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
     __pyx_v_self->has_noninteger_payload = 1;
 
-    /* "noahong.pyx":146
+    /* "noahong.pyx":148
  * 
  *         payload_index = -1
  *         if not isinstance(py_payload, int):             # <<<<<<<<<<<<<<
@@ -2901,7 +2903,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
   }
 
-  /* "noahong.pyx":148
+  /* "noahong.pyx":150
  *         if not isinstance(py_payload, int):
  *             self.has_noninteger_payload = 1
  *         if py_payload is not None:             # <<<<<<<<<<<<<<
@@ -2912,7 +2914,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
   __pyx_t_7 = (__pyx_t_8 != 0);
   if (__pyx_t_7) {
 
-    /* "noahong.pyx":149
+    /* "noahong.pyx":151
  *             self.has_noninteger_payload = 1
  *         if py_payload is not None:
  *             Py_INCREF(py_payload)             # <<<<<<<<<<<<<<
@@ -2921,7 +2923,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
     Py_INCREF(__pyx_v_py_payload);
 
-    /* "noahong.pyx":150
+    /* "noahong.pyx":152
  *         if py_payload is not None:
  *             Py_INCREF(py_payload)
  *             payload_index = len(self.payloads_to_decref)             # <<<<<<<<<<<<<<
@@ -2930,20 +2932,20 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
     __pyx_t_1 = __pyx_v_self->payloads_to_decref;
     __Pyx_INCREF(__pyx_t_1);
-    __pyx_t_9 = PyObject_Length(__pyx_t_1); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 150, __pyx_L1_error)
+    __pyx_t_9 = PyObject_Length(__pyx_t_1); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 152, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_payload_index = __pyx_t_9;
 
-    /* "noahong.pyx":151
+    /* "noahong.pyx":153
  *             Py_INCREF(py_payload)
  *             payload_index = len(self.payloads_to_decref)
  *             self.payloads_to_decref.append(py_payload)             # <<<<<<<<<<<<<<
  * 
  *         self.thisptr.add_string(utf8_data, num_utf8_chars, payload_index)
  */
-    __pyx_t_10 = __Pyx_PyObject_Append(__pyx_v_self->payloads_to_decref, __pyx_v_py_payload); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 151, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_PyObject_Append(__pyx_v_self->payloads_to_decref, __pyx_v_py_payload); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 153, __pyx_L1_error)
 
-    /* "noahong.pyx":148
+    /* "noahong.pyx":150
  *         if not isinstance(py_payload, int):
  *             self.has_noninteger_payload = 1
  *         if py_payload is not None:             # <<<<<<<<<<<<<<
@@ -2952,7 +2954,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
   }
 
-  /* "noahong.pyx":153
+  /* "noahong.pyx":155
  *             self.payloads_to_decref.append(py_payload)
  * 
  *         self.thisptr.add_string(utf8_data, num_utf8_chars, payload_index)             # <<<<<<<<<<<<<<
@@ -2961,17 +2963,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 153, __pyx_L1_error)
+    __PYX_ERR(0, 155, __pyx_L1_error)
   }
-  __pyx_t_11 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_11) && PyErr_Occurred())) __PYX_ERR(0, 153, __pyx_L1_error)
+  __pyx_t_11 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_11) && PyErr_Occurred())) __PYX_ERR(0, 155, __pyx_L1_error)
   try {
     __pyx_v_self->thisptr->add_string(__pyx_t_11, __pyx_v_num_utf8_chars, __pyx_v_payload_index);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 153, __pyx_L1_error)
+    __PYX_ERR(0, 155, __pyx_L1_error)
   }
 
-  /* "noahong.pyx":135
+  /* "noahong.pyx":137
  * #        return
  * 
  *     def add(self, text, py_payload = None):             # <<<<<<<<<<<<<<
@@ -2996,7 +2998,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_18add(struct __pyx_obj_7noahong_NoAho 
   return __pyx_r;
 }
 
-/* "noahong.pyx":159
+/* "noahong.pyx":161
  * #        pass
  * 
  *     def compile(self):             # <<<<<<<<<<<<<<
@@ -3022,7 +3024,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_20compile(struct __pyx_obj_7noahong_No
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("compile", 0);
 
-  /* "noahong.pyx":160
+  /* "noahong.pyx":162
  * 
  *     def compile(self):
  *         self.thisptr.compile()             # <<<<<<<<<<<<<<
@@ -3031,7 +3033,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_20compile(struct __pyx_obj_7noahong_No
  */
   __pyx_v_self->thisptr->compile();
 
-  /* "noahong.pyx":159
+  /* "noahong.pyx":161
  * #        pass
  * 
  *     def compile(self):             # <<<<<<<<<<<<<<
@@ -3046,7 +3048,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_20compile(struct __pyx_obj_7noahong_No
   return __pyx_r;
 }
 
-/* "noahong.pyx":162
+/* "noahong.pyx":164
  *         self.thisptr.compile()
  * 
  *     def find_short(self, text):             # <<<<<<<<<<<<<<
@@ -3090,14 +3092,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("find_short", 0);
 
-  /* "noahong.pyx":170
+  /* "noahong.pyx":172
  *         cdef object py_payload
  *         cdef Utf8CodePoints code_points
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         start = 0
  *         end = 0
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 170, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -3105,7 +3107,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 170, __pyx_L1_error)
+      __PYX_ERR(0, 172, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -3118,15 +3120,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 170, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 170, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 170, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -3134,7 +3136,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 170, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 172, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -3142,17 +3144,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 170, __pyx_L1_error)
+    __PYX_ERR(0, 172, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 170, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 170, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 172, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 172, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":171
+  /* "noahong.pyx":173
  *         cdef Utf8CodePoints code_points
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         start = 0             # <<<<<<<<<<<<<<
@@ -3161,7 +3163,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   __pyx_v_start = 0;
 
-  /* "noahong.pyx":172
+  /* "noahong.pyx":174
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         start = 0
  *         end = 0             # <<<<<<<<<<<<<<
@@ -3170,7 +3172,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   __pyx_v_end = 0;
 
-  /* "noahong.pyx":173
+  /* "noahong.pyx":175
  *         start = 0
  *         end = 0
  *         payload_index = self.thisptr.find_short(utf8_data, num_utf8_chars,             # <<<<<<<<<<<<<<
@@ -3179,11 +3181,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 173, __pyx_L1_error)
+    __PYX_ERR(0, 175, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 173, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 175, __pyx_L1_error)
 
-  /* "noahong.pyx":174
+  /* "noahong.pyx":176
  *         end = 0
  *         payload_index = self.thisptr.find_short(utf8_data, num_utf8_chars,
  *                                                 &start, &end)             # <<<<<<<<<<<<<<
@@ -3194,11 +3196,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     __pyx_t_6 = __pyx_v_self->thisptr->find_short(__pyx_t_7, __pyx_v_num_utf8_chars, (&__pyx_v_start), (&__pyx_v_end));
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 173, __pyx_L1_error)
+    __PYX_ERR(0, 175, __pyx_L1_error)
   }
   __pyx_v_payload_index = __pyx_t_6;
 
-  /* "noahong.pyx":175
+  /* "noahong.pyx":177
  *         payload_index = self.thisptr.find_short(utf8_data, num_utf8_chars,
  *                                                 &start, &end)
  *         py_payload = None             # <<<<<<<<<<<<<<
@@ -3208,7 +3210,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   __Pyx_INCREF(Py_None);
   __pyx_v_py_payload = Py_None;
 
-  /* "noahong.pyx":176
+  /* "noahong.pyx":178
  *                                                 &start, &end)
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -3218,19 +3220,19 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   __pyx_t_8 = ((__pyx_v_payload_index >= 0) != 0);
   if (__pyx_t_8) {
 
-    /* "noahong.pyx":177
+    /* "noahong.pyx":179
  *         py_payload = None
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]             # <<<<<<<<<<<<<<
  *         if start == end:
  *             return None, None, None
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 177, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 179, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_py_payload, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "noahong.pyx":176
+    /* "noahong.pyx":178
  *                                                 &start, &end)
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -3239,7 +3241,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   }
 
-  /* "noahong.pyx":178
+  /* "noahong.pyx":180
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:             # <<<<<<<<<<<<<<
@@ -3249,7 +3251,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   __pyx_t_8 = ((__pyx_v_start == __pyx_v_end) != 0);
   if (__pyx_t_8) {
 
-    /* "noahong.pyx":179
+    /* "noahong.pyx":181
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:
  *             return None, None, None             # <<<<<<<<<<<<<<
@@ -3261,7 +3263,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
     __pyx_r = __pyx_tuple__3;
     goto __pyx_L0;
 
-    /* "noahong.pyx":178
+    /* "noahong.pyx":180
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:             # <<<<<<<<<<<<<<
@@ -3270,7 +3272,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   }
 
-  /* "noahong.pyx":180
+  /* "noahong.pyx":182
  *         if start == end:
  *             return None, None, None
  *         code_points.create(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
@@ -3279,12 +3281,12 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 180, __pyx_L1_error)
+    __PYX_ERR(0, 182, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 180, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 182, __pyx_L1_error)
   __pyx_v_code_points.create(__pyx_t_7, __pyx_v_num_utf8_chars);
 
-  /* "noahong.pyx":181
+  /* "noahong.pyx":183
  *             return None, None, None
  *         code_points.create(utf8_data, num_utf8_chars)
  *         start = code_points.get_codepoint_index(start)             # <<<<<<<<<<<<<<
@@ -3293,7 +3295,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   __pyx_v_start = __pyx_v_code_points.get_codepoint_index(__pyx_v_start);
 
-  /* "noahong.pyx":182
+  /* "noahong.pyx":184
  *         code_points.create(utf8_data, num_utf8_chars)
  *         start = code_points.get_codepoint_index(start)
  *         end = code_points.get_codepoint_index(end)             # <<<<<<<<<<<<<<
@@ -3302,7 +3304,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  */
   __pyx_v_end = __pyx_v_code_points.get_codepoint_index(__pyx_v_end);
 
-  /* "noahong.pyx":183
+  /* "noahong.pyx":185
  *         start = code_points.get_codepoint_index(start)
  *         end = code_points.get_codepoint_index(end)
  *         return start, end, py_payload             # <<<<<<<<<<<<<<
@@ -3310,11 +3312,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
  *     def find_long(self, text):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 183, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 183, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = PyTuple_New(3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 183, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
@@ -3329,7 +3331,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":162
+  /* "noahong.pyx":164
  *         self.thisptr.compile()
  * 
  *     def find_short(self, text):             # <<<<<<<<<<<<<<
@@ -3353,7 +3355,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_22find_short(struct __pyx_obj_7noahong
   return __pyx_r;
 }
 
-/* "noahong.pyx":185
+/* "noahong.pyx":187
  *         return start, end, py_payload
  * 
  *     def find_long(self, text):             # <<<<<<<<<<<<<<
@@ -3397,14 +3399,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("find_long", 0);
 
-  /* "noahong.pyx":192
+  /* "noahong.pyx":194
  *         cdef object py_payload
  *         cdef Utf8CodePoints code_points
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         start = 0
  *         end = 0
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 192, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 194, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -3412,7 +3414,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 192, __pyx_L1_error)
+      __PYX_ERR(0, 194, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -3425,15 +3427,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 192, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 194, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 192, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 194, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 192, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 194, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -3441,7 +3443,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 192, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 194, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -3449,17 +3451,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 192, __pyx_L1_error)
+    __PYX_ERR(0, 194, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 192, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 192, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 194, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 194, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":193
+  /* "noahong.pyx":195
  *         cdef Utf8CodePoints code_points
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         start = 0             # <<<<<<<<<<<<<<
@@ -3468,7 +3470,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   __pyx_v_start = 0;
 
-  /* "noahong.pyx":194
+  /* "noahong.pyx":196
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         start = 0
  *         end = 0             # <<<<<<<<<<<<<<
@@ -3477,7 +3479,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   __pyx_v_end = 0;
 
-  /* "noahong.pyx":195
+  /* "noahong.pyx":197
  *         start = 0
  *         end = 0
  *         payload_index = self.thisptr.find_longest(utf8_data, num_utf8_chars,             # <<<<<<<<<<<<<<
@@ -3486,11 +3488,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 195, __pyx_L1_error)
+    __PYX_ERR(0, 197, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 195, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 197, __pyx_L1_error)
 
-  /* "noahong.pyx":196
+  /* "noahong.pyx":198
  *         end = 0
  *         payload_index = self.thisptr.find_longest(utf8_data, num_utf8_chars,
  *                                                   &start, &end)             # <<<<<<<<<<<<<<
@@ -3501,11 +3503,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     __pyx_t_6 = __pyx_v_self->thisptr->find_longest(__pyx_t_7, __pyx_v_num_utf8_chars, (&__pyx_v_start), (&__pyx_v_end));
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 195, __pyx_L1_error)
+    __PYX_ERR(0, 197, __pyx_L1_error)
   }
   __pyx_v_payload_index = __pyx_t_6;
 
-  /* "noahong.pyx":197
+  /* "noahong.pyx":199
  *         payload_index = self.thisptr.find_longest(utf8_data, num_utf8_chars,
  *                                                   &start, &end)
  *         py_payload = None             # <<<<<<<<<<<<<<
@@ -3515,7 +3517,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   __Pyx_INCREF(Py_None);
   __pyx_v_py_payload = Py_None;
 
-  /* "noahong.pyx":198
+  /* "noahong.pyx":200
  *                                                   &start, &end)
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -3525,19 +3527,19 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   __pyx_t_8 = ((__pyx_v_payload_index >= 0) != 0);
   if (__pyx_t_8) {
 
-    /* "noahong.pyx":199
+    /* "noahong.pyx":201
  *         py_payload = None
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]             # <<<<<<<<<<<<<<
  *         if start == end:
  *             return None, None, None
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 199, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_self->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF_SET(__pyx_v_py_payload, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "noahong.pyx":198
+    /* "noahong.pyx":200
  *                                                   &start, &end)
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -3546,7 +3548,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   }
 
-  /* "noahong.pyx":200
+  /* "noahong.pyx":202
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:             # <<<<<<<<<<<<<<
@@ -3556,7 +3558,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   __pyx_t_8 = ((__pyx_v_start == __pyx_v_end) != 0);
   if (__pyx_t_8) {
 
-    /* "noahong.pyx":201
+    /* "noahong.pyx":203
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:
  *             return None, None, None             # <<<<<<<<<<<<<<
@@ -3568,7 +3570,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
     __pyx_r = __pyx_tuple__3;
     goto __pyx_L0;
 
-    /* "noahong.pyx":200
+    /* "noahong.pyx":202
  *         if payload_index >= 0:
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:             # <<<<<<<<<<<<<<
@@ -3577,7 +3579,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   }
 
-  /* "noahong.pyx":202
+  /* "noahong.pyx":204
  *         if start == end:
  *             return None, None, None
  *         code_points.create(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
@@ -3586,12 +3588,12 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   if (unlikely(__pyx_v_utf8_data == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 202, __pyx_L1_error)
+    __PYX_ERR(0, 204, __pyx_L1_error)
   }
-  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 202, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_7) && PyErr_Occurred())) __PYX_ERR(0, 204, __pyx_L1_error)
   __pyx_v_code_points.create(__pyx_t_7, __pyx_v_num_utf8_chars);
 
-  /* "noahong.pyx":203
+  /* "noahong.pyx":205
  *             return None, None, None
  *         code_points.create(utf8_data, num_utf8_chars)
  *         start = code_points.get_codepoint_index(start)             # <<<<<<<<<<<<<<
@@ -3600,7 +3602,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   __pyx_v_start = __pyx_v_code_points.get_codepoint_index(__pyx_v_start);
 
-  /* "noahong.pyx":204
+  /* "noahong.pyx":206
  *         code_points.create(utf8_data, num_utf8_chars)
  *         start = code_points.get_codepoint_index(start)
  *         end = code_points.get_codepoint_index(end)             # <<<<<<<<<<<<<<
@@ -3609,7 +3611,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  */
   __pyx_v_end = __pyx_v_code_points.get_codepoint_index(__pyx_v_end);
 
-  /* "noahong.pyx":205
+  /* "noahong.pyx":207
  *         start = code_points.get_codepoint_index(start)
  *         end = code_points.get_codepoint_index(end)
  *         return start, end, py_payload             # <<<<<<<<<<<<<<
@@ -3617,11 +3619,11 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
  * # http://thread.gmane.org/gmane.comp.python.cython.user/1920/focus=1921
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 205, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 207, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 205, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_From_int(__pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 207, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = PyTuple_New(3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 205, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 207, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
@@ -3636,7 +3638,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":185
+  /* "noahong.pyx":187
  *         return start, end, py_payload
  * 
  *     def find_long(self, text):             # <<<<<<<<<<<<<<
@@ -3660,7 +3662,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_24find_long(struct __pyx_obj_7noahong_
   return __pyx_r;
 }
 
-/* "noahong.pyx":208
+/* "noahong.pyx":210
  * 
  * # http://thread.gmane.org/gmane.comp.python.cython.user/1920/focus=1921
  *     def findall_short(self, text):             # <<<<<<<<<<<<<<
@@ -3697,14 +3699,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("findall_short", 0);
 
-  /* "noahong.pyx":211
+  /* "noahong.pyx":213
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         # 0 is flag for 'short'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 0)
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 211, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -3712,7 +3714,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 211, __pyx_L1_error)
+      __PYX_ERR(0, 213, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -3725,15 +3727,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 211, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 213, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 211, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 213, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 211, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 213, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -3741,7 +3743,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 211, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 213, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -3749,17 +3751,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 211, __pyx_L1_error)
+    __PYX_ERR(0, 213, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 211, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 211, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 213, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":213
+  /* "noahong.pyx":215
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         # 0 is flag for 'short'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 0)             # <<<<<<<<<<<<<<
@@ -3767,9 +3769,9 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
  *     def findall_long(self, text):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 215, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
@@ -3783,14 +3785,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
   __Pyx_GIVEREF(__pyx_int_0);
   PyTuple_SET_ITEM(__pyx_t_3, 3, __pyx_int_0);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":208
+  /* "noahong.pyx":210
  * 
  * # http://thread.gmane.org/gmane.comp.python.cython.user/1920/focus=1921
  *     def findall_short(self, text):             # <<<<<<<<<<<<<<
@@ -3813,7 +3815,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_26findall_short(struct __pyx_obj_7noah
   return __pyx_r;
 }
 
-/* "noahong.pyx":215
+/* "noahong.pyx":217
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 0)
  * 
  *     def findall_long(self, text):             # <<<<<<<<<<<<<<
@@ -3850,14 +3852,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("findall_long", 0);
 
-  /* "noahong.pyx":218
+  /* "noahong.pyx":220
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         # 1 is flag for 'long'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 1)
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 218, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 220, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -3865,7 +3867,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 218, __pyx_L1_error)
+      __PYX_ERR(0, 220, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -3878,15 +3880,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 218, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 218, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 218, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -3894,7 +3896,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 218, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 220, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -3902,17 +3904,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 218, __pyx_L1_error)
+    __PYX_ERR(0, 220, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 218, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 218, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 220, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":220
+  /* "noahong.pyx":222
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         # 1 is flag for 'long'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 1)             # <<<<<<<<<<<<<<
@@ -3920,9 +3922,9 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
  *     def findall_anchored(self, text):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 222, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 222, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
@@ -3936,14 +3938,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
   __Pyx_GIVEREF(__pyx_int_1);
   PyTuple_SET_ITEM(__pyx_t_3, 3, __pyx_int_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 222, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":215
+  /* "noahong.pyx":217
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 0)
  * 
  *     def findall_long(self, text):             # <<<<<<<<<<<<<<
@@ -3966,7 +3968,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_28findall_long(struct __pyx_obj_7noaho
   return __pyx_r;
 }
 
-/* "noahong.pyx":222
+/* "noahong.pyx":224
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 1)
  * 
  *     def findall_anchored(self, text):             # <<<<<<<<<<<<<<
@@ -4003,14 +4005,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("findall_anchored", 0);
 
-  /* "noahong.pyx":225
+  /* "noahong.pyx":227
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
  *         # 2 is flag for 'long'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 2)
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 225, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -4018,7 +4020,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 225, __pyx_L1_error)
+      __PYX_ERR(0, 227, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -4031,15 +4033,15 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 225, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 225, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 225, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -4047,7 +4049,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 225, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -4055,17 +4057,17 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 225, __pyx_L1_error)
+    __PYX_ERR(0, 227, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 225, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 225, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":227
+  /* "noahong.pyx":229
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
  *         # 2 is flag for 'long'
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 2)             # <<<<<<<<<<<<<<
@@ -4073,9 +4075,9 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
  *     def payloads(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 229, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 229, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
@@ -4089,14 +4091,14 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
   __Pyx_GIVEREF(__pyx_int_2);
   PyTuple_SET_ITEM(__pyx_t_3, 3, __pyx_int_2);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_AhoIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 229, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":222
+  /* "noahong.pyx":224
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 1)
  * 
  *     def findall_anchored(self, text):             # <<<<<<<<<<<<<<
@@ -4119,7 +4121,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_30findall_anchored(struct __pyx_obj_7n
   return __pyx_r;
 }
 
-/* "noahong.pyx":229
+/* "noahong.pyx":231
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 2)
  * 
  *     def payloads(self):             # <<<<<<<<<<<<<<
@@ -4145,7 +4147,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_32payloads(struct __pyx_obj_7noahong_N
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("payloads", 0);
 
-  /* "noahong.pyx":230
+  /* "noahong.pyx":232
  * 
  *     def payloads(self):
  *         return self.payloads_to_decref             # <<<<<<<<<<<<<<
@@ -4157,7 +4159,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_32payloads(struct __pyx_obj_7noahong_N
   __pyx_r = __pyx_v_self->payloads_to_decref;
   goto __pyx_L0;
 
-  /* "noahong.pyx":229
+  /* "noahong.pyx":231
  *         return AhoIterator(self, utf8_data, num_utf8_chars, 2)
  * 
  *     def payloads(self):             # <<<<<<<<<<<<<<
@@ -4285,7 +4287,7 @@ static PyObject *__pyx_pf_7noahong_5NoAho_36__setstate_cython__(CYTHON_UNUSED st
   return __pyx_r;
 }
 
-/* "noahong.pyx":244
+/* "noahong.pyx":246
  *     cdef int start, end, want_longest
  * 
  *     def __init__(self, aho_obj, utf8_data, num_utf8_chars, want_longest):             # <<<<<<<<<<<<<<
@@ -4333,23 +4335,23 @@ static int __pyx_pw_7noahong_11AhoIterator_1__init__(PyObject *__pyx_v_self, PyO
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_utf8_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 1); __PYX_ERR(0, 244, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 1); __PYX_ERR(0, 246, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_num_utf8_chars)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 2); __PYX_ERR(0, 244, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 2); __PYX_ERR(0, 246, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_want_longest)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 3); __PYX_ERR(0, 244, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 3); __PYX_ERR(0, 246, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 244, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 246, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -4366,7 +4368,7 @@ static int __pyx_pw_7noahong_11AhoIterator_1__init__(PyObject *__pyx_v_self, PyO
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 244, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 246, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("noahong.AhoIterator.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -4390,14 +4392,14 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "noahong.pyx":245
+  /* "noahong.pyx":247
  * 
  *     def __init__(self, aho_obj, utf8_data, num_utf8_chars, want_longest):
  *         self.aho_obj = aho_obj             # <<<<<<<<<<<<<<
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)
  */
-  if (!(likely(((__pyx_v_aho_obj) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_aho_obj, __pyx_ptype_7noahong_NoAho))))) __PYX_ERR(0, 245, __pyx_L1_error)
+  if (!(likely(((__pyx_v_aho_obj) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_aho_obj, __pyx_ptype_7noahong_NoAho))))) __PYX_ERR(0, 247, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_aho_obj;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -4406,7 +4408,7 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
   __pyx_v_self->aho_obj = ((struct __pyx_obj_7noahong_NoAho *)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":246
+  /* "noahong.pyx":248
  *     def __init__(self, aho_obj, utf8_data, num_utf8_chars, want_longest):
  *         self.aho_obj = aho_obj
  *         self.code_points = Utf8CodePoints()             # <<<<<<<<<<<<<<
@@ -4415,25 +4417,25 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
  */
   __pyx_v_self->code_points = Utf8CodePoints();
 
-  /* "noahong.pyx":247
+  /* "noahong.pyx":249
  *         self.aho_obj = aho_obj
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars
  */
-  __pyx_t_2 = __Pyx_PyObject_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) __PYX_ERR(0, 247, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 247, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) __PYX_ERR(0, 249, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 249, __pyx_L1_error)
   __pyx_v_self->code_points.create(__pyx_t_2, __pyx_t_3);
 
-  /* "noahong.pyx":248
+  /* "noahong.pyx":250
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)
  *         self.utf8_data = utf8_data             # <<<<<<<<<<<<<<
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0
  */
-  if (!(likely(PyBytes_CheckExact(__pyx_v_utf8_data))||((__pyx_v_utf8_data) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_v_utf8_data)->tp_name), 0))) __PYX_ERR(0, 248, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_v_utf8_data))||((__pyx_v_utf8_data) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_v_utf8_data)->tp_name), 0))) __PYX_ERR(0, 250, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_utf8_data;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -4442,17 +4444,17 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
   __pyx_v_self->utf8_data = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":249
+  /* "noahong.pyx":251
  *         self.code_points.create(utf8_data, num_utf8_chars)
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars             # <<<<<<<<<<<<<<
  *         self.start = 0
  *         self.end = 0
  */
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 249, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 251, __pyx_L1_error)
   __pyx_v_self->num_utf8_chars = __pyx_t_3;
 
-  /* "noahong.pyx":250
+  /* "noahong.pyx":252
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0             # <<<<<<<<<<<<<<
@@ -4461,7 +4463,7 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
  */
   __pyx_v_self->start = 0;
 
-  /* "noahong.pyx":251
+  /* "noahong.pyx":253
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0
  *         self.end = 0             # <<<<<<<<<<<<<<
@@ -4470,17 +4472,17 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
  */
   __pyx_v_self->end = 0;
 
-  /* "noahong.pyx":252
+  /* "noahong.pyx":254
  *         self.start = 0
  *         self.end = 0
  *         self.want_longest = want_longest             # <<<<<<<<<<<<<<
  * 
  *     # I belieeeeve we don't need a __dealloc__ here, that Cython bumps
  */
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_want_longest); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 252, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_want_longest); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 254, __pyx_L1_error)
   __pyx_v_self->want_longest = __pyx_t_3;
 
-  /* "noahong.pyx":244
+  /* "noahong.pyx":246
  *     cdef int start, end, want_longest
  * 
  *     def __init__(self, aho_obj, utf8_data, num_utf8_chars, want_longest):             # <<<<<<<<<<<<<<
@@ -4500,7 +4502,7 @@ static int __pyx_pf_7noahong_11AhoIterator___init__(struct __pyx_obj_7noahong_Ah
   return __pyx_r;
 }
 
-/* "noahong.pyx":258
+/* "noahong.pyx":260
  *     # when we die.
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -4526,7 +4528,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_2__iter__(struct __pyx_obj_7noa
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "noahong.pyx":259
+  /* "noahong.pyx":261
  * 
  *     def __iter__(self):
  *         return self             # <<<<<<<<<<<<<<
@@ -4538,7 +4540,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_2__iter__(struct __pyx_obj_7noa
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "noahong.pyx":258
+  /* "noahong.pyx":260
  *     # when we die.
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
@@ -4553,7 +4555,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_2__iter__(struct __pyx_obj_7noa
   return __pyx_r;
 }
 
-/* "noahong.pyx":261
+/* "noahong.pyx":263
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -4592,7 +4594,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__next__", 0);
 
-  /* "noahong.pyx":268
+  /* "noahong.pyx":270
  *         # I figured a runtime switch was worth not having 2
  *         # iterator types.
  *         if self.want_longest == 1:             # <<<<<<<<<<<<<<
@@ -4602,7 +4604,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
   switch (__pyx_v_self->want_longest) {
     case 1:
 
-    /* "noahong.pyx":270
+    /* "noahong.pyx":272
  *         if self.want_longest == 1:
  *             payload_index = self.aho_obj.thisptr.find_longest(
  *                 self.utf8_data, self.num_utf8_chars,             # <<<<<<<<<<<<<<
@@ -4611,11 +4613,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
     if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 270, __pyx_L1_error)
+      __PYX_ERR(0, 272, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 270, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 272, __pyx_L1_error)
 
-    /* "noahong.pyx":269
+    /* "noahong.pyx":271
  *         # iterator types.
  *         if self.want_longest == 1:
  *             payload_index = self.aho_obj.thisptr.find_longest(             # <<<<<<<<<<<<<<
@@ -4626,11 +4628,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
       __pyx_t_2 = __pyx_v_self->aho_obj->thisptr->find_longest(__pyx_t_1, __pyx_v_self->num_utf8_chars, (&__pyx_v_self->start), (&__pyx_v_self->end));
     } catch(...) {
       try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-      __PYX_ERR(0, 269, __pyx_L1_error)
+      __PYX_ERR(0, 271, __pyx_L1_error)
     }
     __pyx_v_payload_index = __pyx_t_2;
 
-    /* "noahong.pyx":268
+    /* "noahong.pyx":270
  *         # I figured a runtime switch was worth not having 2
  *         # iterator types.
  *         if self.want_longest == 1:             # <<<<<<<<<<<<<<
@@ -4640,7 +4642,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
     break;
     case 2:
 
-    /* "noahong.pyx":274
+    /* "noahong.pyx":276
  *         elif self.want_longest == 2:
  *             payload_index = self.aho_obj.thisptr.find_anchored(
  *                 self.utf8_data, self.num_utf8_chars, 0x1F,             # <<<<<<<<<<<<<<
@@ -4649,11 +4651,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
     if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 274, __pyx_L1_error)
+      __PYX_ERR(0, 276, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 274, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 276, __pyx_L1_error)
 
-    /* "noahong.pyx":273
+    /* "noahong.pyx":275
  *                 &self.start, &self.end)
  *         elif self.want_longest == 2:
  *             payload_index = self.aho_obj.thisptr.find_anchored(             # <<<<<<<<<<<<<<
@@ -4664,11 +4666,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
       __pyx_t_2 = __pyx_v_self->aho_obj->thisptr->find_anchored(__pyx_t_1, __pyx_v_self->num_utf8_chars, 0x1F, (&__pyx_v_self->start), (&__pyx_v_self->end));
     } catch(...) {
       try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-      __PYX_ERR(0, 273, __pyx_L1_error)
+      __PYX_ERR(0, 275, __pyx_L1_error)
     }
     __pyx_v_payload_index = __pyx_t_2;
 
-    /* "noahong.pyx":272
+    /* "noahong.pyx":274
  *                 self.utf8_data, self.num_utf8_chars,
  *                 &self.start, &self.end)
  *         elif self.want_longest == 2:             # <<<<<<<<<<<<<<
@@ -4678,7 +4680,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
     break;
     default:
 
-    /* "noahong.pyx":278
+    /* "noahong.pyx":280
  *         else:
  *             payload_index = self.aho_obj.thisptr.find_short(
  *                 self.utf8_data, self.num_utf8_chars,             # <<<<<<<<<<<<<<
@@ -4687,11 +4689,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
     if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 278, __pyx_L1_error)
+      __PYX_ERR(0, 280, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 278, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 280, __pyx_L1_error)
 
-    /* "noahong.pyx":277
+    /* "noahong.pyx":279
  *                 &self.start, &self.end)
  *         else:
  *             payload_index = self.aho_obj.thisptr.find_short(             # <<<<<<<<<<<<<<
@@ -4702,13 +4704,13 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
       __pyx_t_2 = __pyx_v_self->aho_obj->thisptr->find_short(__pyx_t_1, __pyx_v_self->num_utf8_chars, (&__pyx_v_self->start), (&__pyx_v_self->end));
     } catch(...) {
       try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-      __PYX_ERR(0, 277, __pyx_L1_error)
+      __PYX_ERR(0, 279, __pyx_L1_error)
     }
     __pyx_v_payload_index = __pyx_t_2;
     break;
   }
 
-  /* "noahong.pyx":281
+  /* "noahong.pyx":283
  *                 &self.start, &self.end)
  * 
  *         py_payload = None             # <<<<<<<<<<<<<<
@@ -4718,7 +4720,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
   __Pyx_INCREF(Py_None);
   __pyx_v_py_payload = Py_None;
 
-  /* "noahong.pyx":282
+  /* "noahong.pyx":284
  * 
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -4728,19 +4730,19 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
   __pyx_t_3 = ((__pyx_v_payload_index >= 0) != 0);
   if (__pyx_t_3) {
 
-    /* "noahong.pyx":283
+    /* "noahong.pyx":285
  *         py_payload = None
  *         if payload_index >= 0:
  *             py_payload = self.aho_obj.payloads_to_decref[payload_index]             # <<<<<<<<<<<<<<
  *         if self.start < self.end:
  *             # set up for next time
  */
-    __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_self->aho_obj->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 283, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_self->aho_obj->payloads_to_decref, __pyx_v_payload_index, int32_t, 1, __Pyx_PyInt_From_int32_t, 0, 1, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 285, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF_SET(__pyx_v_py_payload, __pyx_t_4);
     __pyx_t_4 = 0;
 
-    /* "noahong.pyx":282
+    /* "noahong.pyx":284
  * 
  *         py_payload = None
  *         if payload_index >= 0:             # <<<<<<<<<<<<<<
@@ -4749,7 +4751,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
   }
 
-  /* "noahong.pyx":284
+  /* "noahong.pyx":286
  *         if payload_index >= 0:
  *             py_payload = self.aho_obj.payloads_to_decref[payload_index]
  *         if self.start < self.end:             # <<<<<<<<<<<<<<
@@ -4759,7 +4761,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
   __pyx_t_3 = ((__pyx_v_self->start < __pyx_v_self->end) != 0);
   if (likely(__pyx_t_3)) {
 
-    /* "noahong.pyx":286
+    /* "noahong.pyx":288
  *         if self.start < self.end:
  *             # set up for next time
  *             out_start = self.code_points.get_codepoint_index(self.start)             # <<<<<<<<<<<<<<
@@ -4768,7 +4770,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
     __pyx_v_out_start = __pyx_v_self->code_points.get_codepoint_index(__pyx_v_self->start);
 
-    /* "noahong.pyx":287
+    /* "noahong.pyx":289
  *             # set up for next time
  *             out_start = self.code_points.get_codepoint_index(self.start)
  *             out_end = self.code_points.get_codepoint_index(self.end)             # <<<<<<<<<<<<<<
@@ -4777,7 +4779,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
     __pyx_v_out_end = __pyx_v_self->code_points.get_codepoint_index(__pyx_v_self->end);
 
-    /* "noahong.pyx":288
+    /* "noahong.pyx":290
  *             out_start = self.code_points.get_codepoint_index(self.start)
  *             out_end = self.code_points.get_codepoint_index(self.end)
  *             self.start = self.end             # <<<<<<<<<<<<<<
@@ -4787,7 +4789,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
     __pyx_t_2 = __pyx_v_self->end;
     __pyx_v_self->start = __pyx_t_2;
 
-    /* "noahong.pyx":289
+    /* "noahong.pyx":291
  *             out_end = self.code_points.get_codepoint_index(self.end)
  *             self.start = self.end
  *             return out_start, out_end, py_payload             # <<<<<<<<<<<<<<
@@ -4795,11 +4797,11 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  *             raise StopIteration
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_out_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_out_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 291, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_out_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_out_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 291, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 289, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 291, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_4);
     PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_4);
@@ -4814,7 +4816,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
     __pyx_t_6 = 0;
     goto __pyx_L0;
 
-    /* "noahong.pyx":284
+    /* "noahong.pyx":286
  *         if payload_index >= 0:
  *             py_payload = self.aho_obj.payloads_to_decref[payload_index]
  *         if self.start < self.end:             # <<<<<<<<<<<<<<
@@ -4823,7 +4825,7 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
   }
 
-  /* "noahong.pyx":291
+  /* "noahong.pyx":293
  *             return out_start, out_end, py_payload
  *         else:
  *             raise StopIteration             # <<<<<<<<<<<<<<
@@ -4832,10 +4834,10 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_4__next__(struct __pyx_obj_7noa
  */
   /*else*/ {
     __Pyx_Raise(__pyx_builtin_StopIteration, 0, 0, 0);
-    __PYX_ERR(0, 291, __pyx_L1_error)
+    __PYX_ERR(0, 293, __pyx_L1_error)
   }
 
-  /* "noahong.pyx":261
+  /* "noahong.pyx":263
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -4970,10 +4972,10 @@ static PyObject *__pyx_pf_7noahong_11AhoIterator_8__setstate_cython__(CYTHON_UNU
   return __pyx_r;
 }
 
-/* "noahong.pyx":301
- *     cdef int start, end
+/* "noahong.pyx":303
+ *     cdef int start, end, want_longest
  * 
- *     def __init__(self, mapped, utf8_data, num_utf8_chars):             # <<<<<<<<<<<<<<
+ *     def __init__(self, mapped, utf8_data, num_utf8_chars, want_longest):             # <<<<<<<<<<<<<<
  *         self.mapped = mapped
  *         self.code_points = Utf8CodePoints()
  */
@@ -4984,6 +4986,7 @@ static int __pyx_pw_7noahong_14MappedIterator_1__init__(PyObject *__pyx_v_self, 
   PyObject *__pyx_v_mapped = 0;
   PyObject *__pyx_v_utf8_data = 0;
   PyObject *__pyx_v_num_utf8_chars = 0;
+  PyObject *__pyx_v_want_longest = 0;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -4991,12 +4994,14 @@ static int __pyx_pw_7noahong_14MappedIterator_1__init__(PyObject *__pyx_v_self, 
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__init__ (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_mapped,&__pyx_n_s_utf8_data,&__pyx_n_s_num_utf8_chars,0};
-    PyObject* values[3] = {0,0,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_mapped,&__pyx_n_s_utf8_data,&__pyx_n_s_num_utf8_chars,&__pyx_n_s_want_longest,0};
+    PyObject* values[4] = {0,0,0,0};
     if (unlikely(__pyx_kwds)) {
       Py_ssize_t kw_args;
       const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
       switch (pos_args) {
+        case  4: values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
+        CYTHON_FALLTHROUGH;
         case  3: values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
         CYTHON_FALLTHROUGH;
         case  2: values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
@@ -5015,45 +5020,53 @@ static int __pyx_pw_7noahong_14MappedIterator_1__init__(PyObject *__pyx_v_self, 
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_utf8_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, 1); __PYX_ERR(0, 301, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 1); __PYX_ERR(0, 303, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_num_utf8_chars)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, 2); __PYX_ERR(0, 301, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 2); __PYX_ERR(0, 303, __pyx_L3_error)
+        }
+        CYTHON_FALLTHROUGH;
+        case  3:
+        if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_want_longest)) != 0)) kw_args--;
+        else {
+          __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, 3); __PYX_ERR(0, 303, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 301, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) __PYX_ERR(0, 303, __pyx_L3_error)
       }
-    } else if (PyTuple_GET_SIZE(__pyx_args) != 3) {
+    } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
     } else {
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
+      values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
     }
     __pyx_v_mapped = values[0];
     __pyx_v_utf8_data = values[1];
     __pyx_v_num_utf8_chars = values[2];
+    __pyx_v_want_longest = values[3];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 3, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 301, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 303, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("noahong.MappedIterator.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return -1;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_7noahong_14MappedIterator___init__(((struct __pyx_obj_7noahong_MappedIterator *)__pyx_v_self), __pyx_v_mapped, __pyx_v_utf8_data, __pyx_v_num_utf8_chars);
+  __pyx_r = __pyx_pf_7noahong_14MappedIterator___init__(((struct __pyx_obj_7noahong_MappedIterator *)__pyx_v_self), __pyx_v_mapped, __pyx_v_utf8_data, __pyx_v_num_utf8_chars, __pyx_v_want_longest);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self, PyObject *__pyx_v_mapped, PyObject *__pyx_v_utf8_data, PyObject *__pyx_v_num_utf8_chars) {
+static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong_MappedIterator *__pyx_v_self, PyObject *__pyx_v_mapped, PyObject *__pyx_v_utf8_data, PyObject *__pyx_v_num_utf8_chars, PyObject *__pyx_v_want_longest) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -5064,14 +5077,14 @@ static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "noahong.pyx":302
+  /* "noahong.pyx":304
  * 
- *     def __init__(self, mapped, utf8_data, num_utf8_chars):
+ *     def __init__(self, mapped, utf8_data, num_utf8_chars, want_longest):
  *         self.mapped = mapped             # <<<<<<<<<<<<<<
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)
  */
-  if (!(likely(((__pyx_v_mapped) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_mapped, __pyx_ptype_7noahong_Mapped))))) __PYX_ERR(0, 302, __pyx_L1_error)
+  if (!(likely(((__pyx_v_mapped) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_mapped, __pyx_ptype_7noahong_Mapped))))) __PYX_ERR(0, 304, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_mapped;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -5080,8 +5093,8 @@ static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong
   __pyx_v_self->mapped = ((struct __pyx_obj_7noahong_Mapped *)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":303
- *     def __init__(self, mapped, utf8_data, num_utf8_chars):
+  /* "noahong.pyx":305
+ *     def __init__(self, mapped, utf8_data, num_utf8_chars, want_longest):
  *         self.mapped = mapped
  *         self.code_points = Utf8CodePoints()             # <<<<<<<<<<<<<<
  *         self.code_points.create(utf8_data, num_utf8_chars)
@@ -5089,25 +5102,25 @@ static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong
  */
   __pyx_v_self->code_points = Utf8CodePoints();
 
-  /* "noahong.pyx":304
+  /* "noahong.pyx":306
  *         self.mapped = mapped
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars
  */
-  __pyx_t_2 = __Pyx_PyObject_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) __PYX_ERR(0, 304, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 304, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_AsWritableString(__pyx_v_utf8_data); if (unlikely((!__pyx_t_2) && PyErr_Occurred())) __PYX_ERR(0, 306, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 306, __pyx_L1_error)
   __pyx_v_self->code_points.create(__pyx_t_2, __pyx_t_3);
 
-  /* "noahong.pyx":305
+  /* "noahong.pyx":307
  *         self.code_points = Utf8CodePoints()
  *         self.code_points.create(utf8_data, num_utf8_chars)
  *         self.utf8_data = utf8_data             # <<<<<<<<<<<<<<
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0
  */
-  if (!(likely(PyBytes_CheckExact(__pyx_v_utf8_data))||((__pyx_v_utf8_data) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_v_utf8_data)->tp_name), 0))) __PYX_ERR(0, 305, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_v_utf8_data))||((__pyx_v_utf8_data) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_v_utf8_data)->tp_name), 0))) __PYX_ERR(0, 307, __pyx_L1_error)
   __pyx_t_1 = __pyx_v_utf8_data;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
@@ -5116,38 +5129,48 @@ static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong
   __pyx_v_self->utf8_data = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":306
+  /* "noahong.pyx":308
  *         self.code_points.create(utf8_data, num_utf8_chars)
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars             # <<<<<<<<<<<<<<
  *         self.start = 0
  *         self.end = 0
  */
-  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 306, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_num_utf8_chars); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 308, __pyx_L1_error)
   __pyx_v_self->num_utf8_chars = __pyx_t_3;
 
-  /* "noahong.pyx":307
+  /* "noahong.pyx":309
  *         self.utf8_data = utf8_data
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0             # <<<<<<<<<<<<<<
  *         self.end = 0
- * 
+ *         self.want_longest = want_longest
  */
   __pyx_v_self->start = 0;
 
-  /* "noahong.pyx":308
+  /* "noahong.pyx":310
  *         self.num_utf8_chars = num_utf8_chars
  *         self.start = 0
  *         self.end = 0             # <<<<<<<<<<<<<<
+ *         self.want_longest = want_longest
  * 
- *     def __iter__(self):
  */
   __pyx_v_self->end = 0;
 
-  /* "noahong.pyx":301
- *     cdef int start, end
+  /* "noahong.pyx":311
+ *         self.start = 0
+ *         self.end = 0
+ *         self.want_longest = want_longest             # <<<<<<<<<<<<<<
  * 
- *     def __init__(self, mapped, utf8_data, num_utf8_chars):             # <<<<<<<<<<<<<<
+ *     def __iter__(self):
+ */
+  __pyx_t_3 = __Pyx_PyInt_As_int(__pyx_v_want_longest); if (unlikely((__pyx_t_3 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 311, __pyx_L1_error)
+  __pyx_v_self->want_longest = __pyx_t_3;
+
+  /* "noahong.pyx":303
+ *     cdef int start, end, want_longest
+ * 
+ *     def __init__(self, mapped, utf8_data, num_utf8_chars, want_longest):             # <<<<<<<<<<<<<<
  *         self.mapped = mapped
  *         self.code_points = Utf8CodePoints()
  */
@@ -5164,8 +5187,8 @@ static int __pyx_pf_7noahong_14MappedIterator___init__(struct __pyx_obj_7noahong
   return __pyx_r;
 }
 
-/* "noahong.pyx":310
- *         self.end = 0
+/* "noahong.pyx":313
+ *         self.want_longest = want_longest
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
  *         return self
@@ -5190,7 +5213,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_2__iter__(struct __pyx_obj_7
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iter__", 0);
 
-  /* "noahong.pyx":311
+  /* "noahong.pyx":314
  * 
  *     def __iter__(self):
  *         return self             # <<<<<<<<<<<<<<
@@ -5202,8 +5225,8 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_2__iter__(struct __pyx_obj_7
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "noahong.pyx":310
- *         self.end = 0
+  /* "noahong.pyx":313
+ *         self.want_longest = want_longest
  * 
  *     def __iter__(self):             # <<<<<<<<<<<<<<
  *         return self
@@ -5217,7 +5240,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_2__iter__(struct __pyx_obj_7
   return __pyx_r;
 }
 
-/* "noahong.pyx":313
+/* "noahong.pyx":316
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -5256,36 +5279,95 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__next__", 0);
 
-  /* "noahong.pyx":319
- * 
- *         payload_index = self.mapped.trie.find_anchored(
- *             self.utf8_data, self.num_utf8_chars, 0x1F,             # <<<<<<<<<<<<<<
- *             &self.start, &self.end)
- * 
- */
-  if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
-    PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 319, __pyx_L1_error)
-  }
-  __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 319, __pyx_L1_error)
-
-  /* "noahong.pyx":318
+  /* "noahong.pyx":321
  *         cdef int out_start, out_end
  * 
- *         payload_index = self.mapped.trie.find_anchored(             # <<<<<<<<<<<<<<
- *             self.utf8_data, self.num_utf8_chars, 0x1F,
- *             &self.start, &self.end)
+ *         if self.want_longest == 1:             # <<<<<<<<<<<<<<
+ *             payload_index = self.mapped.trie.find_longest(
+ *                 self.utf8_data, self.num_utf8_chars,
  */
-  try {
-    __pyx_t_2 = __pyx_v_self->mapped->trie->find_anchored(__pyx_t_1, __pyx_v_self->num_utf8_chars, 0x1F, (&__pyx_v_self->start), (&__pyx_v_self->end));
-  } catch(...) {
-    try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 318, __pyx_L1_error)
-  }
-  __pyx_v_payload_index = __pyx_t_2;
+  switch (__pyx_v_self->want_longest) {
+    case 1:
 
-  /* "noahong.pyx":322
- *             &self.start, &self.end)
+    /* "noahong.pyx":323
+ *         if self.want_longest == 1:
+ *             payload_index = self.mapped.trie.find_longest(
+ *                 self.utf8_data, self.num_utf8_chars,             # <<<<<<<<<<<<<<
+ *                 &self.start, &self.end)
+ *         elif self.want_longest == 2:
+ */
+    if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
+      PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
+      __PYX_ERR(0, 323, __pyx_L1_error)
+    }
+    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 323, __pyx_L1_error)
+
+    /* "noahong.pyx":322
+ * 
+ *         if self.want_longest == 1:
+ *             payload_index = self.mapped.trie.find_longest(             # <<<<<<<<<<<<<<
+ *                 self.utf8_data, self.num_utf8_chars,
+ *                 &self.start, &self.end)
+ */
+    try {
+      __pyx_t_2 = __pyx_v_self->mapped->trie->find_longest(__pyx_t_1, __pyx_v_self->num_utf8_chars, (&__pyx_v_self->start), (&__pyx_v_self->end));
+    } catch(...) {
+      try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
+      __PYX_ERR(0, 322, __pyx_L1_error)
+    }
+    __pyx_v_payload_index = __pyx_t_2;
+
+    /* "noahong.pyx":321
+ *         cdef int out_start, out_end
+ * 
+ *         if self.want_longest == 1:             # <<<<<<<<<<<<<<
+ *             payload_index = self.mapped.trie.find_longest(
+ *                 self.utf8_data, self.num_utf8_chars,
+ */
+    break;
+    case 2:
+
+    /* "noahong.pyx":327
+ *         elif self.want_longest == 2:
+ *             payload_index = self.mapped.trie.find_anchored(
+ *                 self.utf8_data, self.num_utf8_chars, 0x1F,             # <<<<<<<<<<<<<<
+ *                 &self.start, &self.end)
+ * 
+ */
+    if (unlikely(__pyx_v_self->utf8_data == Py_None)) {
+      PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
+      __PYX_ERR(0, 327, __pyx_L1_error)
+    }
+    __pyx_t_1 = __Pyx_PyBytes_AsWritableString(__pyx_v_self->utf8_data); if (unlikely((!__pyx_t_1) && PyErr_Occurred())) __PYX_ERR(0, 327, __pyx_L1_error)
+
+    /* "noahong.pyx":326
+ *                 &self.start, &self.end)
+ *         elif self.want_longest == 2:
+ *             payload_index = self.mapped.trie.find_anchored(             # <<<<<<<<<<<<<<
+ *                 self.utf8_data, self.num_utf8_chars, 0x1F,
+ *                 &self.start, &self.end)
+ */
+    try {
+      __pyx_t_2 = __pyx_v_self->mapped->trie->find_anchored(__pyx_t_1, __pyx_v_self->num_utf8_chars, 0x1F, (&__pyx_v_self->start), (&__pyx_v_self->end));
+    } catch(...) {
+      try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
+      __PYX_ERR(0, 326, __pyx_L1_error)
+    }
+    __pyx_v_payload_index = __pyx_t_2;
+
+    /* "noahong.pyx":325
+ *                 self.utf8_data, self.num_utf8_chars,
+ *                 &self.start, &self.end)
+ *         elif self.want_longest == 2:             # <<<<<<<<<<<<<<
+ *             payload_index = self.mapped.trie.find_anchored(
+ *                 self.utf8_data, self.num_utf8_chars, 0x1F,
+ */
+    break;
+    default: break;
+  }
+
+  /* "noahong.pyx":330
+ *                 &self.start, &self.end)
  * 
  *         if self.start < self.end:             # <<<<<<<<<<<<<<
  *             # set up for next time
@@ -5294,7 +5376,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
   __pyx_t_3 = ((__pyx_v_self->start < __pyx_v_self->end) != 0);
   if (likely(__pyx_t_3)) {
 
-    /* "noahong.pyx":324
+    /* "noahong.pyx":332
  *         if self.start < self.end:
  *             # set up for next time
  *             out_start = self.code_points.get_codepoint_index(self.start)             # <<<<<<<<<<<<<<
@@ -5303,7 +5385,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
  */
     __pyx_v_out_start = __pyx_v_self->code_points.get_codepoint_index(__pyx_v_self->start);
 
-    /* "noahong.pyx":325
+    /* "noahong.pyx":333
  *             # set up for next time
  *             out_start = self.code_points.get_codepoint_index(self.start)
  *             out_end = self.code_points.get_codepoint_index(self.end)             # <<<<<<<<<<<<<<
@@ -5312,7 +5394,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
  */
     __pyx_v_out_end = __pyx_v_self->code_points.get_codepoint_index(__pyx_v_self->end);
 
-    /* "noahong.pyx":326
+    /* "noahong.pyx":334
  *             out_start = self.code_points.get_codepoint_index(self.start)
  *             out_end = self.code_points.get_codepoint_index(self.end)
  *             self.start = self.end             # <<<<<<<<<<<<<<
@@ -5322,7 +5404,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
     __pyx_t_2 = __pyx_v_self->end;
     __pyx_v_self->start = __pyx_t_2;
 
-    /* "noahong.pyx":327
+    /* "noahong.pyx":335
  *             out_end = self.code_points.get_codepoint_index(self.end)
  *             self.start = self.end
  *             return out_start, out_end, payload_index             # <<<<<<<<<<<<<<
@@ -5330,13 +5412,13 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
  *             raise StopIteration
  */
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_out_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 327, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_out_start); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 335, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_out_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 327, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_out_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 335, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_6 = __Pyx_PyInt_From_int32_t(__pyx_v_payload_index); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 327, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_From_int32_t(__pyx_v_payload_index); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 335, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 327, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 335, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_GIVEREF(__pyx_t_4);
     PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_4);
@@ -5351,8 +5433,8 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
     __pyx_t_7 = 0;
     goto __pyx_L0;
 
-    /* "noahong.pyx":322
- *             &self.start, &self.end)
+    /* "noahong.pyx":330
+ *                 &self.start, &self.end)
  * 
  *         if self.start < self.end:             # <<<<<<<<<<<<<<
  *             # set up for next time
@@ -5360,7 +5442,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
  */
   }
 
-  /* "noahong.pyx":329
+  /* "noahong.pyx":337
  *             return out_start, out_end, payload_index
  *         else:
  *             raise StopIteration             # <<<<<<<<<<<<<<
@@ -5369,10 +5451,10 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_4__next__(struct __pyx_obj_7
  */
   /*else*/ {
     __Pyx_Raise(__pyx_builtin_StopIteration, 0, 0, 0);
-    __PYX_ERR(0, 329, __pyx_L1_error)
+    __PYX_ERR(0, 337, __pyx_L1_error)
   }
 
-  /* "noahong.pyx":313
+  /* "noahong.pyx":316
  *         return self
  * 
  *     def __next__(self):             # <<<<<<<<<<<<<<
@@ -5507,7 +5589,7 @@ static PyObject *__pyx_pf_7noahong_14MappedIterator_8__setstate_cython__(CYTHON_
   return __pyx_r;
 }
 
-/* "noahong.pyx":336
+/* "noahong.pyx":344
  *     cdef bool_t closed
  * 
  *     def __cinit__(self, path):             # <<<<<<<<<<<<<<
@@ -5544,7 +5626,7 @@ static int __pyx_pw_7noahong_6Mapped_1__cinit__(PyObject *__pyx_v_self, PyObject
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 336, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(0, 344, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -5555,7 +5637,7 @@ static int __pyx_pw_7noahong_6Mapped_1__cinit__(PyObject *__pyx_v_self, PyObject
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 336, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 344, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("noahong.Mapped.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -5584,16 +5666,16 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__cinit__", 0);
 
-  /* "noahong.pyx":339
+  /* "noahong.pyx":347
  *         cdef bytes encoded_path
  *         cdef int num_chars
  *         encoded_path = os.fsencode(path)             # <<<<<<<<<<<<<<
  *         num_chars = len(encoded_path)
  *         self.trie = new MappedTrie(encoded_path, num_chars)
  */
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_os); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_os); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 347, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_fsencode); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 339, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_fsencode); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 347, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_t_2 = NULL;
@@ -5608,14 +5690,14 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
   }
   __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_path) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_path);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 339, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 347, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(PyBytes_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 339, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 347, __pyx_L1_error)
   __pyx_v_encoded_path = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "noahong.pyx":340
+  /* "noahong.pyx":348
  *         cdef int num_chars
  *         encoded_path = os.fsencode(path)
  *         num_chars = len(encoded_path)             # <<<<<<<<<<<<<<
@@ -5624,12 +5706,12 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
  */
   if (unlikely(__pyx_v_encoded_path == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 340, __pyx_L1_error)
+    __PYX_ERR(0, 348, __pyx_L1_error)
   }
-  __pyx_t_4 = PyBytes_GET_SIZE(__pyx_v_encoded_path); if (unlikely(__pyx_t_4 == ((Py_ssize_t)-1))) __PYX_ERR(0, 340, __pyx_L1_error)
+  __pyx_t_4 = PyBytes_GET_SIZE(__pyx_v_encoded_path); if (unlikely(__pyx_t_4 == ((Py_ssize_t)-1))) __PYX_ERR(0, 348, __pyx_L1_error)
   __pyx_v_num_chars = __pyx_t_4;
 
-  /* "noahong.pyx":341
+  /* "noahong.pyx":349
  *         encoded_path = os.fsencode(path)
  *         num_chars = len(encoded_path)
  *         self.trie = new MappedTrie(encoded_path, num_chars)             # <<<<<<<<<<<<<<
@@ -5638,18 +5720,18 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
  */
   if (unlikely(__pyx_v_encoded_path == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 341, __pyx_L1_error)
+    __PYX_ERR(0, 349, __pyx_L1_error)
   }
-  __pyx_t_5 = __Pyx_PyBytes_AsWritableString(__pyx_v_encoded_path); if (unlikely((!__pyx_t_5) && PyErr_Occurred())) __PYX_ERR(0, 341, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyBytes_AsWritableString(__pyx_v_encoded_path); if (unlikely((!__pyx_t_5) && PyErr_Occurred())) __PYX_ERR(0, 349, __pyx_L1_error)
   try {
     __pyx_t_6 = new MappedTrie(__pyx_t_5, __pyx_v_num_chars);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) {PyErr_SetString(__pyx_builtin_AssertionError, exn.what());} catch(...) { PyErr_SetNone(__pyx_builtin_AssertionError); }
-    __PYX_ERR(0, 341, __pyx_L1_error)
+    __PYX_ERR(0, 349, __pyx_L1_error)
   }
   __pyx_v_self->trie = __pyx_t_6;
 
-  /* "noahong.pyx":342
+  /* "noahong.pyx":350
  *         num_chars = len(encoded_path)
  *         self.trie = new MappedTrie(encoded_path, num_chars)
  *         self.closed = False             # <<<<<<<<<<<<<<
@@ -5658,7 +5740,7 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
  */
   __pyx_v_self->closed = 0;
 
-  /* "noahong.pyx":336
+  /* "noahong.pyx":344
  *     cdef bool_t closed
  * 
  *     def __cinit__(self, path):             # <<<<<<<<<<<<<<
@@ -5681,7 +5763,7 @@ static int __pyx_pf_7noahong_6Mapped___cinit__(struct __pyx_obj_7noahong_Mapped 
   return __pyx_r;
 }
 
-/* "noahong.pyx":344
+/* "noahong.pyx":352
  *         self.closed = False
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -5705,7 +5787,7 @@ static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Map
   int __pyx_t_1;
   __Pyx_RefNannySetupContext("__dealloc__", 0);
 
-  /* "noahong.pyx":345
+  /* "noahong.pyx":353
  * 
  *     def __dealloc__(self):
  *         if not self.closed:             # <<<<<<<<<<<<<<
@@ -5715,7 +5797,7 @@ static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Map
   __pyx_t_1 = ((!(__pyx_v_self->closed != 0)) != 0);
   if (__pyx_t_1) {
 
-    /* "noahong.pyx":346
+    /* "noahong.pyx":354
  *     def __dealloc__(self):
  *         if not self.closed:
  *             del self.trie             # <<<<<<<<<<<<<<
@@ -5724,7 +5806,7 @@ static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Map
  */
     delete __pyx_v_self->trie;
 
-    /* "noahong.pyx":345
+    /* "noahong.pyx":353
  * 
  *     def __dealloc__(self):
  *         if not self.closed:             # <<<<<<<<<<<<<<
@@ -5733,7 +5815,7 @@ static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Map
  */
   }
 
-  /* "noahong.pyx":344
+  /* "noahong.pyx":352
  *         self.closed = False
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -5745,7 +5827,7 @@ static void __pyx_pf_7noahong_6Mapped_2__dealloc__(struct __pyx_obj_7noahong_Map
   __Pyx_RefNannyFinishContext();
 }
 
-/* "noahong.pyx":348
+/* "noahong.pyx":356
  *             del self.trie
  * 
  *     def close(self):             # <<<<<<<<<<<<<<
@@ -5771,7 +5853,7 @@ static PyObject *__pyx_pf_7noahong_6Mapped_4close(struct __pyx_obj_7noahong_Mapp
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("close", 0);
 
-  /* "noahong.pyx":349
+  /* "noahong.pyx":357
  * 
  *     def close(self):
  *         del self.trie             # <<<<<<<<<<<<<<
@@ -5780,16 +5862,16 @@ static PyObject *__pyx_pf_7noahong_6Mapped_4close(struct __pyx_obj_7noahong_Mapp
  */
   delete __pyx_v_self->trie;
 
-  /* "noahong.pyx":350
+  /* "noahong.pyx":358
  *     def close(self):
  *         del self.trie
  *         self.closed = True             # <<<<<<<<<<<<<<
  * 
- *     def findall_anchored(self, text):
+ *     def findall_long(self, text):
  */
   __pyx_v_self->closed = 1;
 
-  /* "noahong.pyx":348
+  /* "noahong.pyx":356
  *             del self.trie
  * 
  *     def close(self):             # <<<<<<<<<<<<<<
@@ -5804,8 +5886,161 @@ static PyObject *__pyx_pf_7noahong_6Mapped_4close(struct __pyx_obj_7noahong_Mapp
   return __pyx_r;
 }
 
-/* "noahong.pyx":352
+/* "noahong.pyx":360
  *         self.closed = True
+ * 
+ *     def findall_long(self, text):             # <<<<<<<<<<<<<<
+ *         cdef bytes utf8_data
+ *         cdef int num_utf8_chars
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_7noahong_6Mapped_7findall_long(PyObject *__pyx_v_self, PyObject *__pyx_v_text); /*proto*/
+static PyObject *__pyx_pw_7noahong_6Mapped_7findall_long(PyObject *__pyx_v_self, PyObject *__pyx_v_text) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("findall_long (wrapper)", 0);
+  __pyx_r = __pyx_pf_7noahong_6Mapped_6findall_long(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self), ((PyObject *)__pyx_v_text));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_7noahong_6Mapped_6findall_long(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text) {
+  PyObject *__pyx_v_utf8_data = 0;
+  int __pyx_v_num_utf8_chars;
+  PyObject *__pyx_r = NULL;
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  PyObject *(*__pyx_t_5)(PyObject *);
+  int __pyx_t_6;
+  int __pyx_lineno = 0;
+  const char *__pyx_filename = NULL;
+  int __pyx_clineno = 0;
+  __Pyx_RefNannySetupContext("findall_long", 0);
+
+  /* "noahong.pyx":363
+ *         cdef bytes utf8_data
+ *         cdef int num_utf8_chars
+ *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
+ *         # 1 is flag for 'long'
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 1)
+ */
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 363, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
+    PyObject* sequence = __pyx_t_1;
+    Py_ssize_t size = __Pyx_PySequence_SIZE(sequence);
+    if (unlikely(size != 2)) {
+      if (size > 2) __Pyx_RaiseTooManyValuesError(2);
+      else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
+      __PYX_ERR(0, 363, __pyx_L1_error)
+    }
+    #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
+    if (likely(PyTuple_CheckExact(sequence))) {
+      __pyx_t_2 = PyTuple_GET_ITEM(sequence, 0); 
+      __pyx_t_3 = PyTuple_GET_ITEM(sequence, 1); 
+    } else {
+      __pyx_t_2 = PyList_GET_ITEM(sequence, 0); 
+      __pyx_t_3 = PyList_GET_ITEM(sequence, 1); 
+    }
+    __Pyx_INCREF(__pyx_t_2);
+    __Pyx_INCREF(__pyx_t_3);
+    #else
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 363, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_2);
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 363, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    #endif
+    __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  } else {
+    Py_ssize_t index = -1;
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 363, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_4);
+    __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+    __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
+    index = 0; __pyx_t_2 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_2)) goto __pyx_L3_unpacking_failed;
+    __Pyx_GOTREF(__pyx_t_2);
+    index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
+    __Pyx_GOTREF(__pyx_t_3);
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 363, __pyx_L1_error)
+    __pyx_t_5 = NULL;
+    __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+    goto __pyx_L4_unpacking_done;
+    __pyx_L3_unpacking_failed:;
+    __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+    __pyx_t_5 = NULL;
+    if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
+    __PYX_ERR(0, 363, __pyx_L1_error)
+    __pyx_L4_unpacking_done:;
+  }
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 363, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 363, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_v_num_utf8_chars = __pyx_t_6;
+
+  /* "noahong.pyx":365
+ *         utf8_data, num_utf8_chars = get_as_utf8(text)
+ *         # 1 is flag for 'long'
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 1)             # <<<<<<<<<<<<<<
+ * 
+ *     def findall_anchored(self, text):
+ */
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 365, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 365, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_INCREF(((PyObject *)__pyx_v_self));
+  __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
+  PyTuple_SET_ITEM(__pyx_t_3, 0, ((PyObject *)__pyx_v_self));
+  __Pyx_INCREF(__pyx_v_utf8_data);
+  __Pyx_GIVEREF(__pyx_v_utf8_data);
+  PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_v_utf8_data);
+  __Pyx_GIVEREF(__pyx_t_1);
+  PyTuple_SET_ITEM(__pyx_t_3, 2, __pyx_t_1);
+  __Pyx_INCREF(__pyx_int_1);
+  __Pyx_GIVEREF(__pyx_int_1);
+  PyTuple_SET_ITEM(__pyx_t_3, 3, __pyx_int_1);
+  __pyx_t_1 = 0;
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_MappedIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 365, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "noahong.pyx":360
+ *         self.closed = True
+ * 
+ *     def findall_long(self, text):             # <<<<<<<<<<<<<<
+ *         cdef bytes utf8_data
+ *         cdef int num_utf8_chars
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("noahong.Mapped.findall_long", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XDECREF(__pyx_v_utf8_data);
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "noahong.pyx":367
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 1)
  * 
  *     def findall_anchored(self, text):             # <<<<<<<<<<<<<<
  *         cdef bytes utf8_data
@@ -5813,19 +6048,19 @@ static PyObject *__pyx_pf_7noahong_6Mapped_4close(struct __pyx_obj_7noahong_Mapp
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_7noahong_6Mapped_7findall_anchored(PyObject *__pyx_v_self, PyObject *__pyx_v_text); /*proto*/
-static PyObject *__pyx_pw_7noahong_6Mapped_7findall_anchored(PyObject *__pyx_v_self, PyObject *__pyx_v_text) {
+static PyObject *__pyx_pw_7noahong_6Mapped_9findall_anchored(PyObject *__pyx_v_self, PyObject *__pyx_v_text); /*proto*/
+static PyObject *__pyx_pw_7noahong_6Mapped_9findall_anchored(PyObject *__pyx_v_self, PyObject *__pyx_v_text) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("findall_anchored (wrapper)", 0);
-  __pyx_r = __pyx_pf_7noahong_6Mapped_6findall_anchored(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self), ((PyObject *)__pyx_v_text));
+  __pyx_r = __pyx_pf_7noahong_6Mapped_8findall_anchored(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self), ((PyObject *)__pyx_v_text));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text) {
+static PyObject *__pyx_pf_7noahong_6Mapped_8findall_anchored(struct __pyx_obj_7noahong_Mapped *__pyx_v_self, PyObject *__pyx_v_text) {
   PyObject *__pyx_v_utf8_data = 0;
   int __pyx_v_num_utf8_chars;
   PyObject *__pyx_r = NULL;
@@ -5841,14 +6076,14 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("findall_anchored", 0);
 
-  /* "noahong.pyx":355
+  /* "noahong.pyx":370
  *         cdef bytes utf8_data
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(text)             # <<<<<<<<<<<<<<
- *         return MappedIterator(self, utf8_data, num_utf8_chars)
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 2)
  * 
  */
-  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 355, __pyx_L1_error)
+  __pyx_t_1 = __pyx_f_7noahong_get_as_utf8(__pyx_v_text); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 370, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
     PyObject* sequence = __pyx_t_1;
@@ -5856,7 +6091,7 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 355, __pyx_L1_error)
+      __PYX_ERR(0, 370, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -5869,15 +6104,15 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
     __Pyx_INCREF(__pyx_t_2);
     __Pyx_INCREF(__pyx_t_3);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 355, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 370, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 355, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 370, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 355, __pyx_L1_error)
+    __pyx_t_4 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 370, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = Py_TYPE(__pyx_t_4)->tp_iternext;
@@ -5885,7 +6120,7 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
     __Pyx_GOTREF(__pyx_t_2);
     index = 1; __pyx_t_3 = __pyx_t_5(__pyx_t_4); if (unlikely(!__pyx_t_3)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_3);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 355, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_5(__pyx_t_4), 2) < 0) __PYX_ERR(0, 370, __pyx_L1_error)
     __pyx_t_5 = NULL;
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     goto __pyx_L4_unpacking_done;
@@ -5893,27 +6128,27 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_5 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(0, 355, __pyx_L1_error)
+    __PYX_ERR(0, 370, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
-  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 355, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 355, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 370, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 370, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_utf8_data = ((PyObject*)__pyx_t_2);
   __pyx_t_2 = 0;
   __pyx_v_num_utf8_chars = __pyx_t_6;
 
-  /* "noahong.pyx":356
+  /* "noahong.pyx":371
  *         cdef int num_utf8_chars
  *         utf8_data, num_utf8_chars = get_as_utf8(text)
- *         return MappedIterator(self, utf8_data, num_utf8_chars)             # <<<<<<<<<<<<<<
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 2)             # <<<<<<<<<<<<<<
  * 
  *     def nodes_count(self):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 356, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_num_utf8_chars); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 371, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 356, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 371, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
@@ -5923,16 +6158,19 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_v_utf8_data);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 2, __pyx_t_1);
+  __Pyx_INCREF(__pyx_int_2);
+  __Pyx_GIVEREF(__pyx_int_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 3, __pyx_int_2);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_MappedIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 356, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_7noahong_MappedIterator), __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 371, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":352
- *         self.closed = True
+  /* "noahong.pyx":367
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 1)
  * 
  *     def findall_anchored(self, text):             # <<<<<<<<<<<<<<
  *         cdef bytes utf8_data
@@ -5954,27 +6192,27 @@ static PyObject *__pyx_pf_7noahong_6Mapped_6findall_anchored(struct __pyx_obj_7n
   return __pyx_r;
 }
 
-/* "noahong.pyx":358
- *         return MappedIterator(self, utf8_data, num_utf8_chars)
+/* "noahong.pyx":373
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 2)
  * 
  *     def nodes_count(self):             # <<<<<<<<<<<<<<
  *         return self.trie.num_nodes()
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_7noahong_6Mapped_9nodes_count(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static PyObject *__pyx_pw_7noahong_6Mapped_9nodes_count(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_7noahong_6Mapped_11nodes_count(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_7noahong_6Mapped_11nodes_count(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("nodes_count (wrapper)", 0);
-  __pyx_r = __pyx_pf_7noahong_6Mapped_8nodes_count(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self));
+  __pyx_r = __pyx_pf_7noahong_6Mapped_10nodes_count(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_7noahong_6Mapped_8nodes_count(struct __pyx_obj_7noahong_Mapped *__pyx_v_self) {
+static PyObject *__pyx_pf_7noahong_6Mapped_10nodes_count(struct __pyx_obj_7noahong_Mapped *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -5983,20 +6221,20 @@ static PyObject *__pyx_pf_7noahong_6Mapped_8nodes_count(struct __pyx_obj_7noahon
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("nodes_count", 0);
 
-  /* "noahong.pyx":359
+  /* "noahong.pyx":374
  * 
  *     def nodes_count(self):
  *         return self.trie.num_nodes()             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->trie->num_nodes()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 359, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->trie->num_nodes()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 374, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "noahong.pyx":358
- *         return MappedIterator(self, utf8_data, num_utf8_chars)
+  /* "noahong.pyx":373
+ *         return MappedIterator(self, utf8_data, num_utf8_chars, 2)
  * 
  *     def nodes_count(self):             # <<<<<<<<<<<<<<
  *         return self.trie.num_nodes()
@@ -6020,19 +6258,19 @@ static PyObject *__pyx_pf_7noahong_6Mapped_8nodes_count(struct __pyx_obj_7noahon
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_7noahong_6Mapped_11__reduce_cython__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static PyObject *__pyx_pw_7noahong_6Mapped_11__reduce_cython__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_7noahong_6Mapped_13__reduce_cython__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_7noahong_6Mapped_13__reduce_cython__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__reduce_cython__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_7noahong_6Mapped_10__reduce_cython__(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self));
+  __pyx_r = __pyx_pf_7noahong_6Mapped_12__reduce_cython__(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_7noahong_6Mapped_10__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self) {
+static PyObject *__pyx_pf_7noahong_6Mapped_12__reduce_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -6077,19 +6315,19 @@ static PyObject *__pyx_pf_7noahong_6Mapped_10__reduce_cython__(CYTHON_UNUSED str
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_7noahong_6Mapped_13__setstate_cython__(PyObject *__pyx_v_self, PyObject *__pyx_v___pyx_state); /*proto*/
-static PyObject *__pyx_pw_7noahong_6Mapped_13__setstate_cython__(PyObject *__pyx_v_self, PyObject *__pyx_v___pyx_state) {
+static PyObject *__pyx_pw_7noahong_6Mapped_15__setstate_cython__(PyObject *__pyx_v_self, PyObject *__pyx_v___pyx_state); /*proto*/
+static PyObject *__pyx_pw_7noahong_6Mapped_15__setstate_cython__(PyObject *__pyx_v_self, PyObject *__pyx_v___pyx_state) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__setstate_cython__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_7noahong_6Mapped_12__setstate_cython__(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self), ((PyObject *)__pyx_v___pyx_state));
+  __pyx_r = __pyx_pf_7noahong_6Mapped_14__setstate_cython__(((struct __pyx_obj_7noahong_Mapped *)__pyx_v_self), ((PyObject *)__pyx_v___pyx_state));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_7noahong_6Mapped_12__setstate_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self, CYTHON_UNUSED PyObject *__pyx_v___pyx_state) {
+static PyObject *__pyx_pf_7noahong_6Mapped_14__setstate_cython__(CYTHON_UNUSED struct __pyx_obj_7noahong_Mapped *__pyx_v_self, CYTHON_UNUSED PyObject *__pyx_v___pyx_state) {
   PyObject *__pyx_r = NULL;
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
@@ -6591,10 +6829,11 @@ static void __pyx_tp_dealloc_7noahong_Mapped(PyObject *o) {
 
 static PyMethodDef __pyx_methods_7noahong_Mapped[] = {
   {"close", (PyCFunction)__pyx_pw_7noahong_6Mapped_5close, METH_NOARGS, 0},
-  {"findall_anchored", (PyCFunction)__pyx_pw_7noahong_6Mapped_7findall_anchored, METH_O, 0},
-  {"nodes_count", (PyCFunction)__pyx_pw_7noahong_6Mapped_9nodes_count, METH_NOARGS, 0},
-  {"__reduce_cython__", (PyCFunction)__pyx_pw_7noahong_6Mapped_11__reduce_cython__, METH_NOARGS, 0},
-  {"__setstate_cython__", (PyCFunction)__pyx_pw_7noahong_6Mapped_13__setstate_cython__, METH_O, 0},
+  {"findall_long", (PyCFunction)__pyx_pw_7noahong_6Mapped_7findall_long, METH_O, 0},
+  {"findall_anchored", (PyCFunction)__pyx_pw_7noahong_6Mapped_9findall_anchored, METH_O, 0},
+  {"nodes_count", (PyCFunction)__pyx_pw_7noahong_6Mapped_11nodes_count, METH_NOARGS, 0},
+  {"__reduce_cython__", (PyCFunction)__pyx_pw_7noahong_6Mapped_13__reduce_cython__, METH_NOARGS, 0},
+  {"__setstate_cython__", (PyCFunction)__pyx_pw_7noahong_6Mapped_15__setstate_cython__, METH_O, 0},
   {0, 0, 0, 0}
 };
 
@@ -6766,11 +7005,11 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
 };
 static CYTHON_SMALL_CODE int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_AssertionError = __Pyx_GetBuiltinName(__pyx_n_s_AssertionError); if (!__pyx_builtin_AssertionError) __PYX_ERR(0, 47, __pyx_L1_error)
-  __pyx_builtin_BaseException = __Pyx_GetBuiltinName(__pyx_n_s_BaseException); if (!__pyx_builtin_BaseException) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_builtin_BaseException = __Pyx_GetBuiltinName(__pyx_n_s_BaseException); if (!__pyx_builtin_BaseException) __PYX_ERR(0, 79, __pyx_L1_error)
   __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 37, __pyx_L1_error)
-  __pyx_builtin_KeyError = __Pyx_GetBuiltinName(__pyx_n_s_KeyError); if (!__pyx_builtin_KeyError) __PYX_ERR(0, 125, __pyx_L1_error)
+  __pyx_builtin_KeyError = __Pyx_GetBuiltinName(__pyx_n_s_KeyError); if (!__pyx_builtin_KeyError) __PYX_ERR(0, 127, __pyx_L1_error)
   __pyx_builtin_TypeError = __Pyx_GetBuiltinName(__pyx_n_s_TypeError); if (!__pyx_builtin_TypeError) __PYX_ERR(1, 2, __pyx_L1_error)
-  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 291, __pyx_L1_error)
+  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 293, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -6791,25 +7030,25 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple_);
   __Pyx_GIVEREF(__pyx_tuple_);
 
-  /* "noahong.pyx":143
+  /* "noahong.pyx":145
  * 
  *         if num_utf8_chars == 0:
  *             raise ValueError("Key cannot be empty (would cause Aho-Corasick automaton to spin)")             # <<<<<<<<<<<<<<
  * 
  *         payload_index = -1
  */
-  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_s_Key_cannot_be_empty_would_cause); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_s_Key_cannot_be_empty_would_cause); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(0, 145, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__2);
   __Pyx_GIVEREF(__pyx_tuple__2);
 
-  /* "noahong.pyx":179
+  /* "noahong.pyx":181
  *             py_payload = self.payloads_to_decref[payload_index]
  *         if start == end:
  *             return None, None, None             # <<<<<<<<<<<<<<
  *         code_points.create(utf8_data, num_utf8_chars)
  *         start = code_points.get_codepoint_index(start)
  */
-  __pyx_tuple__3 = PyTuple_Pack(3, Py_None, Py_None, Py_None); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 179, __pyx_L1_error)
+  __pyx_tuple__3 = PyTuple_Pack(3, Py_None, Py_None, Py_None); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 181, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__3);
   __Pyx_GIVEREF(__pyx_tuple__3);
 
@@ -6889,14 +7128,14 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__11);
   __Pyx_GIVEREF(__pyx_tuple__11);
 
-  /* "noahong.pyx":77
+  /* "noahong.pyx":79
  *         int num_nodes()
  * 
  * class PayloadWriteError(BaseException):             # <<<<<<<<<<<<<<
  *     pass
  * 
  */
-  __pyx_tuple__12 = PyTuple_Pack(1, __pyx_builtin_BaseException); if (unlikely(!__pyx_tuple__12)) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_tuple__12 = PyTuple_Pack(1, __pyx_builtin_BaseException); if (unlikely(!__pyx_tuple__12)) __PYX_ERR(0, 79, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__12);
   __Pyx_GIVEREF(__pyx_tuple__12);
   __Pyx_RefNannyFinishContext();
@@ -6955,45 +7194,45 @@ static int __Pyx_modinit_type_init_code(void) {
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__Pyx_modinit_type_init_code", 0);
   /*--- Type init code ---*/
-  if (PyType_Ready(&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 80, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 82, __pyx_L1_error)
   #if PY_VERSION_HEX < 0x030800B1
   __pyx_type_7noahong_NoAho.tp_print = 0;
   #endif
   if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type_7noahong_NoAho.tp_dictoffset && __pyx_type_7noahong_NoAho.tp_getattro == PyObject_GenericGetAttr)) {
     __pyx_type_7noahong_NoAho.tp_getattro = __Pyx_PyObject_GenericGetAttr;
   }
-  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_NoAho, (PyObject *)&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 80, __pyx_L1_error)
-  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 80, __pyx_L1_error)
+  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_NoAho, (PyObject *)&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 82, __pyx_L1_error)
+  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_NoAho) < 0) __PYX_ERR(0, 82, __pyx_L1_error)
   __pyx_ptype_7noahong_NoAho = &__pyx_type_7noahong_NoAho;
-  if (PyType_Ready(&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 237, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 239, __pyx_L1_error)
   #if PY_VERSION_HEX < 0x030800B1
   __pyx_type_7noahong_AhoIterator.tp_print = 0;
   #endif
   if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type_7noahong_AhoIterator.tp_dictoffset && __pyx_type_7noahong_AhoIterator.tp_getattro == PyObject_GenericGetAttr)) {
     __pyx_type_7noahong_AhoIterator.tp_getattro = __Pyx_PyObject_GenericGetAttr;
   }
-  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_AhoIterator, (PyObject *)&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 237, __pyx_L1_error)
-  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 237, __pyx_L1_error)
+  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_AhoIterator, (PyObject *)&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 239, __pyx_L1_error)
+  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_AhoIterator) < 0) __PYX_ERR(0, 239, __pyx_L1_error)
   __pyx_ptype_7noahong_AhoIterator = &__pyx_type_7noahong_AhoIterator;
-  if (PyType_Ready(&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 294, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 296, __pyx_L1_error)
   #if PY_VERSION_HEX < 0x030800B1
   __pyx_type_7noahong_MappedIterator.tp_print = 0;
   #endif
   if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type_7noahong_MappedIterator.tp_dictoffset && __pyx_type_7noahong_MappedIterator.tp_getattro == PyObject_GenericGetAttr)) {
     __pyx_type_7noahong_MappedIterator.tp_getattro = __Pyx_PyObject_GenericGetAttr;
   }
-  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_MappedIterator, (PyObject *)&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 294, __pyx_L1_error)
-  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 294, __pyx_L1_error)
+  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_MappedIterator, (PyObject *)&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 296, __pyx_L1_error)
+  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_MappedIterator) < 0) __PYX_ERR(0, 296, __pyx_L1_error)
   __pyx_ptype_7noahong_MappedIterator = &__pyx_type_7noahong_MappedIterator;
-  if (PyType_Ready(&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 332, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 340, __pyx_L1_error)
   #if PY_VERSION_HEX < 0x030800B1
   __pyx_type_7noahong_Mapped.tp_print = 0;
   #endif
   if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type_7noahong_Mapped.tp_dictoffset && __pyx_type_7noahong_Mapped.tp_getattro == PyObject_GenericGetAttr)) {
     __pyx_type_7noahong_Mapped.tp_getattro = __Pyx_PyObject_GenericGetAttr;
   }
-  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_Mapped, (PyObject *)&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 332, __pyx_L1_error)
-  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 332, __pyx_L1_error)
+  if (PyObject_SetAttr(__pyx_m, __pyx_n_s_Mapped, (PyObject *)&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 340, __pyx_L1_error)
+  if (__Pyx_setup_reduce((PyObject*)&__pyx_type_7noahong_Mapped) < 0) __PYX_ERR(0, 340, __pyx_L1_error)
   __pyx_ptype_7noahong_Mapped = &__pyx_type_7noahong_Mapped;
   __Pyx_RefNannyFinishContext();
   return 0;
@@ -7261,20 +7500,20 @@ if (!__Pyx_RefNanny) {
   if (PyDict_SetItem(__pyx_d, __pyx_n_s_os, __pyx_t_1) < 0) __PYX_ERR(0, 25, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "noahong.pyx":77
+  /* "noahong.pyx":79
  *         int num_nodes()
  * 
  * class PayloadWriteError(BaseException):             # <<<<<<<<<<<<<<
  *     pass
  * 
  */
-  __pyx_t_1 = __Pyx_CalculateMetaclass(NULL, __pyx_tuple__12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_CalculateMetaclass(NULL, __pyx_tuple__12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 79, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_Py3MetaclassPrepare(__pyx_t_1, __pyx_tuple__12, __pyx_n_s_PayloadWriteError, __pyx_n_s_PayloadWriteError, (PyObject *) NULL, __pyx_n_s_noahong, (PyObject *) NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_Py3MetaclassPrepare(__pyx_t_1, __pyx_tuple__12, __pyx_n_s_PayloadWriteError, __pyx_n_s_PayloadWriteError, (PyObject *) NULL, __pyx_n_s_noahong, (PyObject *) NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 79, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_Py3ClassCreate(__pyx_t_1, __pyx_n_s_PayloadWriteError, __pyx_tuple__12, __pyx_t_2, NULL, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 77, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_Py3ClassCreate(__pyx_t_1, __pyx_n_s_PayloadWriteError, __pyx_tuple__12, __pyx_t_2, NULL, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 79, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_PayloadWriteError, __pyx_t_3) < 0) __PYX_ERR(0, 77, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_PayloadWriteError, __pyx_t_3) < 0) __PYX_ERR(0, 79, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;


### PR DESCRIPTION
Currently, the `Mapped` matcher only implements the `anchored` matching mode.

Here I implement the `findall_longest` for Mapped matcher, and rewrite tests previously only running on a `NoAho` object to run with a `Mapped` object.
