### PR TITLE
setup: wildcard in version specifier causes build issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
         "Environment :: Console",
         "Topic :: Text Processing",
     ],
-    python_requires=">=3.6.*, <4",
+    python_requires=">=3.6, <4",
 )


### PR DESCRIPTION
Hello :wave: @pquentin !

I have recently been running into some issues when building noahong:

```
    × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [1 lines of output]
        error in noahong setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.6.*'
        [end of output]
```

It it not clear from PEP 440 whether the comparison with a wildcard is allowed, and I thought it was perfectly valid (has been for years 😬 ).

As it turns out, `packaging` does not support comparisons (other than `==`) with wildcard version specifiers.

They even have a test for it:
https://github.com/pypa/packaging/blob/e2bc8f6ef2d66f6eaaf522fcf70a0f203b734064/tests/test_specifiers.py#L65-L69

See this conversation on PEP 440
https://discuss.python.org/t/pep-440-wildcard-usage-in-comparison-clause/10045/5

In any event, this new specifier is equivalent, so I guess we can just use it.